### PR TITLE
Iterate on how we handle post-external-authentication errors

### DIFF
--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Web/AzureADUserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Web/AzureADUserAuthenticatedAction.cs
@@ -5,13 +5,14 @@ using Octopus.Server.Extensibility.Authentication.AzureAD.Tokens;
 using Octopus.Server.Extensibility.Authentication.HostServices;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Infrastructure;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web;
+using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
 using Octopus.Time;
 
 namespace Octopus.Server.Extensibility.Authentication.AzureAD.Web
 {
     public class AzureADUserAuthenticatedAction : UserAuthenticatedAction<IAzureADConfigurationStore, IAzureADAuthTokenHandler>
     {
-        public AzureADUserAuthenticatedAction(ILog log, IAzureADAuthTokenHandler authTokenHandler, IPrincipalToUserHandler principalToUserHandler, IUserStore userStore, IAzureADConfigurationStore configurationStore, IAuthCookieCreator authCookieCreator, IInvalidLoginTracker loginTracker, ISleep sleep) : base(log, authTokenHandler, principalToUserHandler, userStore, configurationStore, authCookieCreator, loginTracker, sleep)
+        public AzureADUserAuthenticatedAction(ILog log, IAzureADAuthTokenHandler authTokenHandler, IPrincipalToUserHandler principalToUserHandler, IUserStore userStore, IAzureADConfigurationStore configurationStore, IApiActionResponseCreator responseCreator, IAuthCookieCreator authCookieCreator, IInvalidLoginTracker loginTracker, ISleep sleep) : base(log, authTokenHandler, principalToUserHandler, userStore, configurationStore, responseCreator, authCookieCreator, loginTracker, sleep)
         {
         }
     }

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Web/AzureADUserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Web/AzureADUserAuthenticatedAction.cs
@@ -12,7 +12,7 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD.Web
 {
     public class AzureADUserAuthenticatedAction : UserAuthenticatedAction<IAzureADConfigurationStore, IAzureADAuthTokenHandler>
     {
-        public AzureADUserAuthenticatedAction(ILog log, IAzureADAuthTokenHandler authTokenHandler, IPrincipalToUserHandler principalToUserHandler, IUserStore userStore, IAzureADConfigurationStore configurationStore, IApiActionResponseCreator responseCreator, IAuthCookieCreator authCookieCreator, IInvalidLoginTracker loginTracker, ISleep sleep) : base(log, authTokenHandler, principalToUserHandler, userStore, configurationStore, responseCreator, authCookieCreator, loginTracker, sleep)
+        public AzureADUserAuthenticatedAction(ILog log, IAzureADAuthTokenHandler authTokenHandler, IPrincipalToUserResourceMapper principalToUserResourceMapper, IUserStore userStore, IAzureADConfigurationStore configurationStore, IApiActionResponseCreator responseCreator, IAuthCookieCreator authCookieCreator, IInvalidLoginTracker loginTracker, ISleep sleep) : base(log, authTokenHandler, principalToUserResourceMapper, userStore, configurationStore, responseCreator, authCookieCreator, loginTracker, sleep)
         {
         }
     }

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Web/GoogleAppsUserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Web/GoogleAppsUserAuthenticatedAction.cs
@@ -5,13 +5,14 @@ using Octopus.Server.Extensibility.Authentication.GoogleApps.Tokens;
 using Octopus.Server.Extensibility.Authentication.HostServices;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Infrastructure;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web;
+using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
 using Octopus.Time;
 
 namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Web
 {
     public class GoogleAppsUserAuthenticatedAction : UserAuthenticatedAction<IGoogleAppsConfigurationStore, IGoogleAuthTokenHandler>
     {
-        public GoogleAppsUserAuthenticatedAction(ILog log, IGoogleAuthTokenHandler authTokenHandler, IPrincipalToUserHandler principalToUserHandler, IUserStore userStore, IGoogleAppsConfigurationStore configurationStore, IAuthCookieCreator authCookieCreator, IInvalidLoginTracker loginTracker, ISleep sleep) : base(log, authTokenHandler, principalToUserHandler, userStore, configurationStore, authCookieCreator, loginTracker, sleep)
+        public GoogleAppsUserAuthenticatedAction(ILog log, IGoogleAuthTokenHandler authTokenHandler, IPrincipalToUserHandler principalToUserHandler, IUserStore userStore, IGoogleAppsConfigurationStore configurationStore, IApiActionResponseCreator responseCreator, IAuthCookieCreator authCookieCreator, IInvalidLoginTracker loginTracker, ISleep sleep) : base(log, authTokenHandler, principalToUserHandler, userStore, configurationStore, responseCreator, authCookieCreator, loginTracker, sleep)
         {
         }
     }

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Web/GoogleAppsUserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Web/GoogleAppsUserAuthenticatedAction.cs
@@ -12,7 +12,7 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Web
 {
     public class GoogleAppsUserAuthenticatedAction : UserAuthenticatedAction<IGoogleAppsConfigurationStore, IGoogleAuthTokenHandler>
     {
-        public GoogleAppsUserAuthenticatedAction(ILog log, IGoogleAuthTokenHandler authTokenHandler, IPrincipalToUserHandler principalToUserHandler, IUserStore userStore, IGoogleAppsConfigurationStore configurationStore, IApiActionResponseCreator responseCreator, IAuthCookieCreator authCookieCreator, IInvalidLoginTracker loginTracker, ISleep sleep) : base(log, authTokenHandler, principalToUserHandler, userStore, configurationStore, responseCreator, authCookieCreator, loginTracker, sleep)
+        public GoogleAppsUserAuthenticatedAction(ILog log, IGoogleAuthTokenHandler authTokenHandler, IPrincipalToUserResourceMapper principalToUserResourceMapper, IUserStore userStore, IGoogleAppsConfigurationStore configurationStore, IApiActionResponseCreator responseCreator, IAuthCookieCreator authCookieCreator, IInvalidLoginTracker loginTracker, ISleep sleep) : base(log, authTokenHandler, principalToUserResourceMapper, userStore, configurationStore, responseCreator, authCookieCreator, loginTracker, sleep)
         {
         }
     }

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Infrastructure/IPrincipalToUserResourceMapper.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Infrastructure/IPrincipalToUserResourceMapper.cs
@@ -2,8 +2,8 @@
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Infrastructure
 {
-    public interface IPrincipalToUserHandler
+    public interface IPrincipalToUserResourceMapper
     {
-        UserResource GetUserResource(ClaimsPrincipal principal);
+        UserResource MapToUserResource(ClaimsPrincipal principal);
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Infrastructure/PrincipalToUserResourceMapper.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Infrastructure/PrincipalToUserResourceMapper.cs
@@ -3,9 +3,9 @@ using System.Security.Claims;
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Infrastructure
 {
-    public class PrincipalToUserResourceHandler : IPrincipalToUserHandler
+    public class PrincipalToUserResourceMapper : IPrincipalToUserResourceMapper
     {
-        public UserResource GetUserResource(ClaimsPrincipal principal)
+        public UserResource MapToUserResource(ClaimsPrincipal principal)
         {
             var userResource = new UserResource
             {

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
@@ -130,8 +130,8 @@
     <Compile Include="Issuer\IIdentityProviderConfigDiscoverer.cs" />
     <Compile Include="Tokens\ClaimsPrincipleContainer.cs" />
     <Compile Include="Tokens\IAuthTokenHandler.cs" />
-    <Compile Include="Infrastructure\IPrincipalToUserHandler.cs" />
-    <Compile Include="Infrastructure\PrincipalToUserResourceHandler.cs" />
+    <Compile Include="Infrastructure\IPrincipalToUserResourceMapper.cs" />
+    <Compile Include="Infrastructure\PrincipalToUserResourceMapper.cs" />
     <Compile Include="Tokens\OpenIDConnectAuthTokenHandler.cs" />
     <Compile Include="Infrastructure\UserResource.cs" />
     <Compile Include="Issuer\IssuerConfiguration.cs" />

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/OpenIdConnectExtension.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/OpenIdConnectExtension.cs
@@ -8,7 +8,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect
     {
         public virtual void Load(ContainerBuilder builder)
         {
-            builder.RegisterType<PrincipalToUserResourceHandler>().As<IPrincipalToUserHandler>().InstancePerDependency();
+            builder.RegisterType<PrincipalToUserResourceMapper>().As<IPrincipalToUserResourceMapper>().InstancePerDependency();
             builder.RegisterType<IdentityProviderConfigDiscoverer>().As<IIdentityProviderConfigDiscoverer>().SingleInstance();
         }
     }

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Web/UserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Web/UserAuthenticatedAction.cs
@@ -24,7 +24,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
     {
         readonly ILog log;
         readonly TAuthTokenHandler authTokenHandler;
-        readonly IPrincipalToUserHandler principalToUserHandler;
+        readonly IPrincipalToUserResourceMapper principalToUserResourceMapper;
         readonly IUserStore userStore;
         readonly IAuthCookieCreator authCookieCreator;
         readonly IInvalidLoginTracker loginTracker;
@@ -36,7 +36,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
         protected UserAuthenticatedAction(
             ILog log,
             TAuthTokenHandler authTokenHandler,
-            IPrincipalToUserHandler principalToUserHandler,
+            IPrincipalToUserResourceMapper principalToUserResourceMapper,
             IUserStore userStore,
             TStore configurationStore,
             IApiActionResponseCreator responseCreator, 
@@ -46,7 +46,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
         {
             this.log = log;
             this.authTokenHandler = authTokenHandler;
-            this.principalToUserHandler = principalToUserHandler;
+            this.principalToUserResourceMapper = principalToUserResourceMapper;
             this.userStore = userStore;
             ConfigurationStore = configurationStore;
             ResponseCreator = responseCreator;
@@ -57,6 +57,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
 
         public async Task<Response> ExecuteAsync(NancyContext context, IResponseFormatter response)
         {
+
             string stateFromRequest;
             var principalContainer = await authTokenHandler.GetPrincipalAsync(context.Request, out stateFromRequest);
             var principal = principalContainer.principal;
@@ -115,7 +116,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
                 return ResponseCreator.BadRequest(message);
             }
 
-            var model = principalToUserHandler.GetUserResource(principal);
+            var model = principalToUserResourceMapper.MapToUserResource(principal);
 
             var action = loginTracker.BeforeAttempt(model.Username, context.Request.UserHostAddress);
             if (action == InvalidLoginAction.Ban)


### PR DESCRIPTION
After testing fairly thoroughly I believe we need to avoid using the Query String as a communication protocol to the sign in page. Each of these errors which can occur really indicate a Bad Request in some form or another.

At least this way the error is noisy and accessible, and should be less susceptible to side-effecting the application.

I've also removed a handful of duplicate error handling logic.

Relates to https://github.com/OctopusDeploy/Issues/issues/2988