### PR TITLE
Updating validation around the issuer for OpenID login providers

### DIFF
--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/AzureADAuthenticationProvider.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/AzureADAuthenticationProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Configuration;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect;
@@ -15,8 +16,11 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD
 
         protected override IEnumerable<string> ReasonsWhyConfigIsIncomplete()
         {
-            if (string.IsNullOrWhiteSpace(ConfigurationStore.GetIssuer()))
+            var issuer = ConfigurationStore.GetIssuer();
+            if (string.IsNullOrWhiteSpace(issuer))
                 yield return $"No {IdentityProviderName} issuer specified";
+            if (!Uri.IsWellFormedUriString(issuer, UriKind.Absolute))
+                yield return $"The {IdentityProviderName} issuer must be an absolute URI (expected format: https://login.microsoftonline.com/[issuer guid])";
             if (string.IsNullOrWhiteSpace(ConfigurationStore.GetClientId()))
                 yield return $"No {IdentityProviderName} Client ID specified";
         }

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/GoogleAppsAuthenticationProvider.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/GoogleAppsAuthenticationProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect;
@@ -15,8 +16,11 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps
 
         protected override IEnumerable<string> ReasonsWhyConfigIsIncomplete()
         {
-            if (string.IsNullOrWhiteSpace(ConfigurationStore.GetIssuer()))
+            var issuer = ConfigurationStore.GetIssuer();
+            if (string.IsNullOrWhiteSpace(issuer))
                 yield return $"No {IdentityProviderName} issuer specified";
+            if (!Uri.IsWellFormedUriString(issuer, UriKind.Absolute))
+                yield return $"The {IdentityProviderName} issuer must be an absolute URI (expected format: https://accounts.google.com)";
             if (string.IsNullOrWhiteSpace(ConfigurationStore.GetClientId()))
                 yield return $"No {IdentityProviderName} Client ID specified";
             if (string.IsNullOrWhiteSpace(ConfigurationStore.GetHostedDomain()))

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationStore.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationStore.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Nevermore.Contracts;
 using Octopus.Data.Storage.Configuration;
 using Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration;
@@ -37,6 +38,8 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuratio
 
         public void SetIssuer(string issuer)
         {
+            if (!Uri.IsWellFormedUriString(issuer, UriKind.Absolute))
+                throw new ArgumentException($"The {ConfigurationSettingsName} issuer must be an absolute URI (expected format: https://login.microsoftonline.com/[issuer guid])");
             ConfigurationStore.CreateOrUpdate<TConfiguration>(SingletonId, doc => doc.Issuer = issuer);
         }
 

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationStore.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationStore.cs
@@ -38,8 +38,11 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuratio
 
         public void SetIssuer(string issuer)
         {
+            Guid issuerAsGuid;
+            if (Guid.TryParse(issuer, out issuerAsGuid))
+                throw new ArgumentException($"The {ConfigurationSettingsName} issuer must be an absolute URI and not a GUID (please refer to the Octopus auth-provider's documentation for details)");
             if (!Uri.IsWellFormedUriString(issuer, UriKind.Absolute))
-                throw new ArgumentException($"The {ConfigurationSettingsName} issuer must be an absolute URI (expected format: https://login.microsoftonline.com/[issuer guid])");
+                throw new ArgumentException($"The {ConfigurationSettingsName} issuer must be an absolute URI (please refer to the Octopus auth-provider's documentation for details)");
             ConfigurationStore.CreateOrUpdate<TConfiguration>(SingletonId, doc => doc.Issuer = issuer);
         }
 

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/OpenIDConnectAuthenticationProvider.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/OpenIDConnectAuthenticationProvider.cs
@@ -23,7 +23,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect
 
         public bool IsEnabled => ConfigurationStore.GetIsEnabled() && IsProviderConfigComplete();
 
-        private bool IsProviderConfigComplete()
+        bool IsProviderConfigComplete()
         {
             var isComplete = true;
             foreach (var reason in ReasonsWhyConfigIsIncomplete())


### PR DESCRIPTION
Updating validation around the issuer for OpenID login providers so this is clear when you run the `configure` command against your Octopus Server that this should be an absolute uri.

If they've already run a bad configure 'issuer' command against their instance, the `ReasonsWhyConfigIsIncomplete` validation will detect an invalid issuer URI and generate a log in their server logs.

If they're running the configure command from this point on, and try to call `SetIssuer` for their given login provider, it will now detect if they're trying to enter a GUID and inform them accordingly (and then fallback to also check if it's a valid URI).

Once this PR is approved, I'll make another PR for Octopus.Server (to include this updated version) and merge.

Fixes OctopusDeploy/Issues#3379