### PR TITLE
Improvements to key cache handling

### DIFF
--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Issuer/AzureADKeyRetriever.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Issuer/AzureADKeyRetriever.cs
@@ -6,7 +6,7 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD.Issuer
 {
     public class AzureADKeyRetriever : KeyRetriever<IAzureADConfigurationStore, IKeyJsonParser>, IAzureADKeyRetriever
     {
-        public AzureADKeyRetriever(IClock clock, IAzureADConfigurationStore configurationStore, IKeyJsonParser keyParser) : base(clock, configurationStore, keyParser)
+        public AzureADKeyRetriever(IClock clock, IAzureADConfigurationStore configurationStore, IKeyJsonParser keyParser) : base(configurationStore, keyParser)
         {
         }
     }

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Issuer/GoogleKeyRetriever.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Issuer/GoogleKeyRetriever.cs
@@ -6,7 +6,7 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Issuer
 {
     public class GoogleKeyRetriever : KeyRetriever<IGoogleAppsConfigurationStore, IKeyJsonParser>, IGoogleKeyRetriever
     {
-        public GoogleKeyRetriever(IClock clock, IGoogleAppsConfigurationStore configurationStore, IKeyJsonParser keyParser) : base(clock, configurationStore, keyParser)
+        public GoogleKeyRetriever(IClock clock, IGoogleAppsConfigurationStore configurationStore, IKeyJsonParser keyParser) : base(configurationStore, keyParser)
         {
         }
     }

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Certificates/IKeyRetriever.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Certificates/IKeyRetriever.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Tokens;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Issuer;
@@ -9,5 +8,6 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Certificates
     public interface IKeyRetriever
     {
         Task<IDictionary<string, AsymmetricSecurityKey>> GetCertificatesAsync(IssuerConfiguration issuerConfiguration);
+        void FlushCache();
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Certificates/IKeyRetriever.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Certificates/IKeyRetriever.cs
@@ -7,7 +7,6 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Certificates
 {
     public interface IKeyRetriever
     {
-        Task<IDictionary<string, AsymmetricSecurityKey>> GetCertificatesAsync(IssuerConfiguration issuerConfiguration);
-        void FlushCache();
+        Task<IDictionary<string, AsymmetricSecurityKey>> GetCertificatesAsync(IssuerConfiguration issuerConfiguration, bool forceReload=false);
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Certificates/KeyRetriever.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Certificates/KeyRetriever.cs
@@ -29,24 +29,16 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Certificates
             this.keyParser = keyParser;
         }
 
-        public void FlushCache()
+        public Task<IDictionary<string, AsymmetricSecurityKey>> GetCertificatesAsync(IssuerConfiguration issuerConfiguration, bool forceReload=false)
         {
             lock (funcLock)
             {
-                certRetrieveTask = null;
-            }
-        }
-
-        public Task<IDictionary<string, AsymmetricSecurityKey>> GetCertificatesAsync(IssuerConfiguration issuerConfiguration)
-        {
-            lock (funcLock)
-            {
-                if (certRetrieveTask != null)
+                if (certRetrieveTask != null && !forceReload)
                     return certRetrieveTask;
 
                 certRetrieveTask = DoGetKeyAsync(issuerConfiguration);
-            }
-            return certRetrieveTask;
+                return certRetrieveTask;
+            }           
         }
 
         protected virtual string GetDownloadUri(IssuerConfiguration issuerConfiguration)

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/Helpers/RS256AlgorithmRsaOnly.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/Helpers/RS256AlgorithmRsaOnly.cs
@@ -1,0 +1,27 @@
+﻿using JWT;
+using JWT.Algorithms;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octopus.Server.Extensibility.Authentication.Tests.Helpers
+{
+    public class RS256AlgorithmRsaOnly : IJwtAlgorithm
+    {
+        readonly RSACryptoServiceProvider rsa;
+        public RS256AlgorithmRsaOnly(RSACryptoServiceProvider rsa)
+        {
+            this.rsa = rsa;
+        }
+
+        public string Name => JwtHashAlgorithm.RS256.ToString();
+
+        public byte[] Sign(byte[] key, byte[] bytesToSign)
+        {
+            return rsa.SignData(bytesToSign, CryptoConfig.MapNameToOID("SHA256"));
+        }
+    }
+}

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -87,6 +87,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Solution Items\SolutionInfo.cs">
+      <Link>Properties\SolutionInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\Solution Items\VersionInfo.cs">
+      <Link>Properties\VersionInfo.cs</Link>
+    </Compile>
     <Compile Include="Helpers\RS256AlgorithmRsaOnly.cs" />
     <Compile Include="OpenIdConnect\Tokens\CustomOpenIDConnectAuthTokenHandler.cs" />
     <Compile Include="OpenIdConnect\Tokens\OpenIDConnectAuthTokenHandlerFixture.cs" />

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
@@ -1,0 +1,111 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{00680371-A6E1-435F-9966-2450C2723E91}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Octopus.Server.Extensibility.Authentication.Tests</RootNamespace>
+    <AssemblyName>Octopus.Server.Extensibility.Authentication.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="JWT, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\JWT.3.0.1\lib\net35\JWT.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=1.0.0.127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.1.0.0\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.0.0.127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.0.0\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Nancy, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nancy.1.4.1\lib\net40\Nancy.dll</HintPath>
+    </Reference>
+    <Reference Include="Nancy.Serialization.JsonNet, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nancy.Serialization.JsonNet.1.2.0\lib\net40\Nancy.Serialization.JsonNet.dll</HintPath>
+    </Reference>
+    <Reference Include="Nevermore.Contracts, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nevermore.Contracts.1.0.1\lib\netstandard1.0\Nevermore.Contracts.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="NSubstitute, Version=1.8.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.8.2.0\lib\net45\NSubstitute.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Versioning, Version=3.4.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Versioning.3.4.3\lib\net45\NuGet.Versioning.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Octopus.Data, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Data.1.0.8\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="Octopus.Diagnostics, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Diagnostics.1.0.12\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
+    </Reference>
+    <Reference Include="Octopus.Server.Extensibility, Version=2.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Server.Extensibility.2.0.2\lib\net45\Octopus.Server.Extensibility.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.0.0.127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.0.0\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Helpers\RS256AlgorithmRsaOnly.cs" />
+    <Compile Include="OpenIdConnect\Tokens\CustomOpenIDConnectAuthTokenHandler.cs" />
+    <Compile Include="OpenIdConnect\Tokens\OpenIDConnectAuthTokenHandlerFixture.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Octopus.Server.Extensibility.Authentication.AzureAD\Octopus.Server.Extensibility.Authentication.AzureAD.csproj">
+      <Project>{8CBCE54C-D501-4ED8-A716-DE64AE5198DA}</Project>
+      <Name>Octopus.Server.Extensibility.Authentication.AzureAD</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Octopus.Server.Extensibility.Authentication.OpenIDConnect\Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj">
+      <Project>{90829768-9b06-475d-ac73-c9c6e0f20acb}</Project>
+      <Name>Octopus.Server.Extensibility.Authentication.OpenIdConnect</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/CustomOpenIDConnectAuthTokenHandler.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/CustomOpenIDConnectAuthTokenHandler.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Octopus.Diagnostics;
+using Octopus.Server.Extensibility.Authentication.AzureAD.Configuration;
+using Octopus.Server.Extensibility.Authentication.AzureAD.Tokens;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Certificates;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Issuer;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
+
+namespace Octopus.Server.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
+{
+    public class CustomOpenIDConnectAuthTokenHandler : OpenIDConnectAuthTokenHandler<IOpenIDConnectConfigurationStore, IKeyRetriever>
+    { 
+        public CustomOpenIDConnectAuthTokenHandler(ILog log, IOpenIDConnectConfigurationStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
+        {
+            
+        }
+    }
+
+}

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/OpenIDConnectAuthTokenHandlerFixture.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/OpenIDConnectAuthTokenHandlerFixture.cs
@@ -1,0 +1,278 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Nancy;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Diagnostics;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Certificates;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Issuer;
+using Microsoft.IdentityModel.Tokens;
+using System.Security.Claims;
+using JWT.Serializers;
+using JWT;
+using Octopus.Server.Extensibility.Authentication.Tests.Helpers;
+
+namespace Octopus.Server.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
+{
+    [TestFixture]
+    public class OpenIDConnectAuthTokenHandlerFixture
+    {
+        ILog log;
+        IOpenIDConnectConfigurationStore configurationStore;
+        IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer;
+        IKeyRetriever keyRetriever;
+        CustomOpenIDConnectAuthTokenHandler target;
+
+        const string DefaultIssuer = "https://somedomain.com/";
+        const string DefaultClientId = "Octopus Deploy";
+        const string DefaultSubject = "12345";
+        const string DefaultName = "bob";
+        const string DefaultEmail = "bob@somedomain.com";
+
+        const string KeyId = "88a8e79fba13856b4159f96e9c9ea6d5";
+        const string Nonce = "";
+
+        [SetUp]
+        public void SetUp()
+        {
+            log = Substitute.For<ILog>();
+            configurationStore = Substitute.For<IOpenIDConnectConfigurationStore>();
+            identityProviderConfigDiscoverer = Substitute.For<IIdentityProviderConfigDiscoverer>();
+            keyRetriever = Substitute.For<IKeyRetriever>();
+
+            target = new CustomOpenIDConnectAuthTokenHandler(
+                log,
+                configurationStore,
+                identityProviderConfigDiscoverer,
+                keyRetriever);
+        }
+
+        [Test]
+        public async void ShouldReturnPrincipalWhenValidTokenReceived()
+        {
+            // Arrange
+            RsaSecurityKey rsaSecurityKeyPublic;
+            var token = CreateToken(KeyId, out rsaSecurityKeyPublic);
+            var issuerConfig = new IssuerConfiguration() {Issuer = DefaultIssuer };
+            var key = new Dictionary<string, AsymmetricSecurityKey>() { { KeyId, rsaSecurityKeyPublic } };
+
+            var request = createRequest(token);
+
+            configurationStore.GetIssuer().Returns(DefaultIssuer);
+            configurationStore.GetClientId().Returns(DefaultClientId);
+
+            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+                .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
+
+            keyRetriever.GetCertificatesAsync(issuerConfig, false)
+                .Returns(Task.FromResult<IDictionary<string, AsymmetricSecurityKey>>(key));
+
+            // Act
+            string state;
+            var result = await target.GetPrincipalAsync(request, out state);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNullOrEmpty(result.error);
+            Assert.IsNotNull(result.principal);
+            Assert.AreEqual("/state/", state);
+
+            AssertClaims(result.principal);
+
+            configurationStore.Received().GetIssuer();
+            configurationStore.Received().GetClientId();
+            Received.InOrder(async () => { await keyRetriever.GetCertificatesAsync(issuerConfig, false); });
+
+        }
+
+
+        [Test]
+        public async void ShouldRetryWhenInvalidKeyDetected()
+        {
+            // Arrange
+            RsaSecurityKey rsaSecurityKeyStale;
+            RsaSecurityKey rsaSecurityKeyCurrent;
+
+            var token = CreateToken("99a8e79fba13856b4159f96e9c9ea6d5", out rsaSecurityKeyStale);
+            token = CreateToken(KeyId, out rsaSecurityKeyCurrent);
+            var issuerConfig = new IssuerConfiguration() { Issuer = DefaultIssuer };
+            var key = new Dictionary<string, AsymmetricSecurityKey>() { { KeyId, rsaSecurityKeyCurrent } };
+            var staleKey = new Dictionary<string, AsymmetricSecurityKey>() { { "99a8e79fba13856b4159f96e9c9ea6d5", rsaSecurityKeyStale } };
+
+            var request = createRequest(token);
+
+            configurationStore.GetIssuer().Returns(DefaultIssuer);
+            configurationStore.GetClientId().Returns(DefaultClientId);
+
+            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+                .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
+
+            // On first call to keyRetriever return invalid (stale) key
+            keyRetriever.GetCertificatesAsync(issuerConfig, false)
+                .Returns(Task.FromResult<IDictionary<string, AsymmetricSecurityKey>>(staleKey));
+
+            // On second call return the new valid key
+            keyRetriever.GetCertificatesAsync(issuerConfig, true)
+                .Returns(Task.FromResult<IDictionary<string, AsymmetricSecurityKey>>(key));
+
+            // Act
+            string state;
+            var result = await target.GetPrincipalAsync(request, out state);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNullOrEmpty(result.error);
+            Assert.IsNotNull(result.principal);
+            Assert.AreEqual("/state/", state);
+
+            AssertClaims(result.principal);
+
+            configurationStore.Received().GetIssuer();
+            configurationStore.Received().GetClientId();
+
+            Received.InOrder(async () => { await keyRetriever.GetCertificatesAsync(issuerConfig, false); });
+            Received.InOrder(async () => { await keyRetriever.GetCertificatesAsync(issuerConfig, true); });
+        }
+
+
+        [Test]
+        [ExpectedException(typeof(SecurityTokenInvalidSignatureException), ExpectedMessage = @"IDX10500: Signature validation failed. There are no security keys to use to validate the signature")]
+        public async void ShouldThrowWhenInvalidKeyDetectedTwice()
+        {
+            // Arrange
+            RsaSecurityKey rsaSecurityKeyStale;
+            RsaSecurityKey rsaSecurityKeyCurrent;
+
+            var token = CreateToken("99a8e79fba13856b4159f96e9c9ea6d5", out rsaSecurityKeyStale);
+            token = CreateToken(KeyId, out rsaSecurityKeyCurrent);
+            var issuerConfig = new IssuerConfiguration() { Issuer = DefaultIssuer };
+            var staleKey = new Dictionary<string, AsymmetricSecurityKey>() { { "99a8e79fba13856b4159f96e9c9ea6d5", rsaSecurityKeyStale } };
+
+            var request = createRequest(token);
+
+            configurationStore.GetIssuer().Returns(DefaultIssuer);
+            configurationStore.GetClientId().Returns(DefaultClientId);
+
+            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+                .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
+
+            // set keyRetriever to always return invalid (stale) key
+            keyRetriever.GetCertificatesAsync(issuerConfig)
+                .ReturnsForAnyArgs(Task.FromResult<IDictionary<string, AsymmetricSecurityKey>>(staleKey));
+
+            // Act
+            string state;
+            var result = await target.GetPrincipalAsync(request, out state);
+
+            // Expect Exception Thrown
+
+        }
+
+        [Test]
+        [TestCase("https://someotherdomain.com", DefaultClientId, Description = "Invalid Issuer", ExpectedException = typeof(SecurityTokenInvalidIssuerException))]
+        [TestCase(DefaultIssuer, "Another Client", Description = "Invalid ClientId", ExpectedException = typeof(SecurityTokenInvalidAudienceException))]
+        public async void ShouldThrowWhenInvalidTokenDetected(string issuer, string clientId)
+        {
+            // Arrange
+            RsaSecurityKey rsaSecurityKeyPublic;
+            var token = CreateToken(KeyId, out rsaSecurityKeyPublic, issuer: issuer, clientId: clientId);
+            var issuerConfig = new IssuerConfiguration() { Issuer = DefaultIssuer };
+            var key = new Dictionary<string, AsymmetricSecurityKey>() { { KeyId, rsaSecurityKeyPublic } };
+
+            var request = createRequest(token);
+
+            configurationStore.GetIssuer().Returns(DefaultIssuer);
+            configurationStore.GetClientId().Returns(DefaultClientId);
+
+            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+                .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
+
+            keyRetriever.GetCertificatesAsync(issuerConfig, false)
+                .Returns(Task.FromResult<IDictionary<string, AsymmetricSecurityKey>>(key));
+
+            // Act
+            string state;
+            var result = await target.GetPrincipalAsync(request, out state);
+
+            // Expect Exception Thrown
+
+        }
+
+
+        Request createRequest(string token)
+        {
+            var request = new Request("POST", DefaultIssuer);
+            request.Form["access_token"] = null;
+            request.Form["id_token"] = token;
+            request.Form["state"] = "/state/";
+            return request;
+        }
+
+        string CreateToken(
+            string keyId,
+            out RsaSecurityKey key,
+            string issuer = DefaultIssuer,
+            string clientId = DefaultClientId,
+            string nonce = Nonce,
+            string subject = DefaultSubject,
+            string name = DefaultName,
+            string email = DefaultEmail)
+        {
+            var epoch = new DateTime(1970, 1, 1);
+            var now = Math.Round((DateTime.Now - epoch).TotalSeconds);
+            var exp = now + 36000;
+
+            var payload = new Dictionary<string, object>
+            {
+                { "aud", clientId },
+                { "iss", issuer },
+                { "exp", exp },
+                { "iat", now },
+                { "nonce", nonce },
+                { "sub", subject},
+                { "name", name},
+                { "email", email}
+            };
+
+            var headers = new Dictionary<string, object>
+            {
+                { "kid",  keyId}
+            };
+
+            using (var rsa = new RSACryptoServiceProvider(2048))
+            {
+                var rsaParametersPublic = rsa.ExportParameters(includePrivateParameters: false);
+                key = new RsaSecurityKey(rsaParametersPublic) {KeyId = keyId};
+
+                var algorithm = new RS256AlgorithmRsaOnly(rsa);
+                var serializer = new JsonNetSerializer();
+                var urlEncoder = new JwtBase64UrlEncoder();
+                var encoder = new JwtEncoder(algorithm, serializer, urlEncoder);
+                var token = encoder.Encode(headers, payload, string.Empty);
+
+                return token;
+            }
+        }
+
+        void AssertClaims(
+            ClaimsPrincipal principal,
+            string issuer = DefaultIssuer,
+            string clientid = DefaultClientId,
+            string nonce = Nonce,
+            string subject = DefaultSubject,
+            string name = DefaultName,
+            string email = DefaultEmail)
+        {
+            Assert.IsTrue(principal.HasClaim(x => x.Type == "iss" && x.Value == issuer));
+            Assert.IsTrue(principal.HasClaim(x => x.Type == "aud" && x.Value == clientid));
+            Assert.IsTrue(principal.HasClaim(x => x.Type == "nonce" && x.Value == nonce));
+            Assert.IsTrue(principal.HasClaim(x => x.Type == "name" && x.Value == name));
+            Assert.IsTrue(principal.HasClaim(x => x.Type == ClaimTypes.NameIdentifier && x.Value == subject));
+            Assert.IsTrue(principal.HasClaim(x => x.Type == ClaimTypes.Email && x.Value == email));
+        }
+
+    }
+}

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/Properties/AssemblyInfo.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/Properties/AssemblyInfo.cs
@@ -1,36 +1,3 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Octopus.Server.Extensibility.Authentication.Tests")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Octopus.Server.Extensibility.Authentication.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("00680371-a6e1-435f-9966-2450c2723e91")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/Properties/AssemblyInfo.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Octopus.Server.Extensibility.Authentication.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Octopus.Server.Extensibility.Authentication.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("00680371-a6e1-435f-9966-2450c2723e91")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/app.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Autofac" version="3.5.2" targetFramework="net451" />
+  <package id="JWT" version="3.0.1" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Logging" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.0.0" targetFramework="net451" />
+  <package id="Nancy" version="1.4.1" targetFramework="net451" />
+  <package id="Nancy.Serialization.JsonNet" version="1.2.0" targetFramework="net451" />
+  <package id="Nevermore.Contracts" version="1.0.1" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
+  <package id="NSubstitute" version="1.8.2.0" targetFramework="net451" />
+  <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
+  <package id="NUnit" version="2.6.4" targetFramework="net451" />
+  <package id="Octopus.Data" version="1.0.8" targetFramework="net451" />
+  <package id="Octopus.Diagnostics" version="1.0.12" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility" version="2.0.2" targetFramework="net451" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net451" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.0.0" targetFramework="net451" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net451" />
+</packages>

--- a/source/OpenIDConnectAuthenticationProvider.sln
+++ b/source/OpenIDConnectAuthenticationProvider.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{953D2520-3518-4A89-A335-72547D5B8EAD}"
 	ProjectSection(SolutionItems) = preProject
@@ -14,6 +14,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Octopus.Server.Extensibility.Authentication.AzureAD", "Octopus.Server.Extensibility.Authentication.AzureAD\Octopus.Server.Extensibility.Authentication.AzureAD.csproj", "{8CBCE54C-D501-4ED8-A716-DE64AE5198DA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Octopus.Server.Extensibility.Authentication.GoogleApps", "Octopus.Server.Extensibility.Authentication.GoogleApps\Octopus.Server.Extensibility.Authentication.GoogleApps.csproj", "{6796E715-F1FA-445D-AF1F-F6C9023A8D07}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{C354DA8E-D532-4DAE-8D61-E4F50A0139C8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Octopus.Server.Extensibility.Authentication.Tests", "Octopus.Server.Extensibility.Authentication.Tests\Octopus.Server.Extensibility.Authentication.Tests.csproj", "{00680371-A6E1-435F-9966-2450C2723E91}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,8 +37,15 @@ Global
 		{6796E715-F1FA-445D-AF1F-F6C9023A8D07}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6796E715-F1FA-445D-AF1F-F6C9023A8D07}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6796E715-F1FA-445D-AF1F-F6C9023A8D07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00680371-A6E1-435F-9966-2450C2723E91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00680371-A6E1-435F-9966-2450C2723E91}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00680371-A6E1-435F-9966-2450C2723E91}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00680371-A6E1-435F-9966-2450C2723E91}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{00680371-A6E1-435F-9966-2450C2723E91} = {C354DA8E-D532-4DAE-8D61-E4F50A0139C8}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Relates to https://github.com/OctopusDeploy/Issues/issues/3621

Summary of changes:
 + Simplified caching logic in the KeyRetriever and provided flag to force cache reload.
 + GetPrincipalFromToken will now, upon detection of invalid signature, flush the cache, reload the keys before validating token.
 + The audience & issuer token parameters are now validated
 + Added unit tests to verify the GetPrincipalAsync/GetPrincipalFromToken methods of the OpenIDConnectAuthTokenHandler
