### PR TITLE
Identity support

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,1 +1,1 @@
-mode: Mainline
+mode: ContinuousDeployment

--- a/source/NuGet.Config
+++ b/source/NuGet.Config
@@ -18,9 +18,6 @@
 
   </packageSources>
 
-  <disabledPackageSources>
-    <!-- Add any package sources to ignore here using the same keys as 
-         defined in the packageSources list above-->
-  </disabledPackageSources>
+  <disabledPackageSources />
 
 </configuration>

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/AzureADApi.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/AzureADApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Configuration;
+using Octopus.Server.Extensibility.Authentication.AzureAD.Identities;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Tokens;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Web;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect;
@@ -7,7 +8,7 @@ using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
 
 namespace Octopus.Server.Extensibility.Authentication.AzureAD
 {
-    public class AzureADApi : OpenIDConnectModule<AzureADUserAuthenticationAction, IAzureADConfigurationStore, AzureADUserAuthenticatedAction, IAzureADAuthTokenHandler>
+    public class AzureADApi : OpenIDConnectModule<AzureADUserAuthenticationAction, IAzureADConfigurationStore, AzureADUserAuthenticatedAction, IAzureADAuthTokenHandler, IAzureADIdentityCreator>
     {
         public AzureADApi(
             IAzureADConfigurationStore configurationStore, 

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/AzureADAuthenticationProvider.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/AzureADAuthenticationProvider.cs
@@ -8,11 +8,13 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD
 {
     public class AzureADAuthenticationProvider : OpenIDConnectAuthenticationProvider<IAzureADConfigurationStore>
     {
+        public const string ProviderName = "Azure AD";
+
         public AzureADAuthenticationProvider(ILog log, IAzureADConfigurationStore configurationStore) : base(log, configurationStore)
         {
         }
 
-        public override string IdentityProviderName => "Azure AD";
+        public override string IdentityProviderName => ProviderName;
 
         protected override IEnumerable<string> ReasonsWhyConfigIsIncomplete()
         {

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/AzureADExtension.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/AzureADExtension.cs
@@ -6,6 +6,7 @@ using Octopus.Server.Extensibility.Authentication.AzureAD.Issuer;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Tokens;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Web;
 using Octopus.Server.Extensibility.Authentication.Extensions;
+using Octopus.Server.Extensibility.Authentication.Extensions.Identities;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Certificates;
 using Octopus.Server.Extensibility.Extensions;
@@ -59,6 +60,7 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD
             builder.RegisterType<AzureADAuthenticationProvider>()
                 .As<IAuthenticationProvider>()
                 .As<IAuthenticationProviderWithGroupSupport>()
+                .As<IUseAuthenticationIdentities>()
                 .AsSelf()
                 .InstancePerDependency();
         }

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/AzureADExtension.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/AzureADExtension.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Configuration;
+using Octopus.Server.Extensibility.Authentication.AzureAD.Identities;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Infrastructure;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Issuer;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Tokens;
@@ -23,6 +24,8 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD
 
             builder.RegisterType<AzureADPrincipalToUserResourceMapper>().As<IAzureADPrincipalToUserResourceMapper>().InstancePerDependency();
             builder.RegisterType<AzureADConfigurationMapping>().As<IConfigurationDocumentMapper>().InstancePerDependency();
+
+            builder.RegisterType<AzureADIdentityCreator>().As<IAzureADIdentityCreator>().SingleInstance();
 
             builder.RegisterType<AzureADConfigurationStore>()
                 .As<IAzureADConfigurationStore>()

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Identities/AzureADIdentityCreator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Identities/AzureADIdentityCreator.cs
@@ -1,0 +1,12 @@
+﻿using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Identities;
+
+namespace Octopus.Server.Extensibility.Authentication.AzureAD.Identities
+{
+    public class AzureADIdentityCreator : IdentityCreator, IAzureADIdentityCreator
+    {
+        protected override string ProviderName => AzureADAuthenticationProvider.ProviderName;
+    }
+
+    public interface IAzureADIdentityCreator : IIdentityCreator
+    { }
+}

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0025\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0026\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0013\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0015\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0006\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0009\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
@@ -52,7 +52,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Nevermore.Contracts, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nevermore.Contracts.4.0.0-enh-odcm0053\lib\net451\Nevermore.Contracts.dll</HintPath>
+      <HintPath>..\packages\Nevermore.Contracts.4.0.0\lib\net451\Nevermore.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -66,8 +66,8 @@
       <HintPath>..\packages\Octopus.Configuration.1.0.10\lib\net45\Octopus.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0033\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+    <Reference Include="Octopus.Data, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Data.2.0.1\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0026\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0019\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0032\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0012\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0021\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>
@@ -119,6 +119,7 @@
     <Compile Include="Configuration\IAzureADConfigurationStore.cs" />
     <Compile Include="Configuration\AzureADConfigurationMapping.cs" />
     <Compile Include="Configuration\AzureADConfigurationStore.cs" />
+    <Compile Include="Identities\AzureADIdentityCreator.cs" />
     <Compile Include="Infrastructure\AzureADPrincipalToUserResourceMapper.cs" />
     <Compile Include="Infrastructure\IAzureADPrincipalToUserResourceMapper.cs" />
     <Compile Include="Web\AzureADCSSContributor.cs" />

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0017\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0019\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0010\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0012\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
@@ -51,9 +51,8 @@
       <HintPath>..\packages\Nancy.Serialization.JsonNet.1.2.0\lib\net40\Nancy.Serialization.JsonNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Nevermore.Contracts, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nevermore.Contracts.1.0.1\lib\netstandard1.0\Nevermore.Contracts.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Nevermore.Contracts, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nevermore.Contracts.4.0.0-enh-odcm0053\lib\net451\Nevermore.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -67,9 +66,8 @@
       <HintPath>..\packages\Octopus.Configuration.1.0.10\lib\net45\Octopus.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Data, Version=1.0.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.1.0.18\lib\netstandard1.0\Octopus.Data.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0013\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -79,9 +77,8 @@
       <HintPath>..\packages\Octopus.Server.Extensibility.2.0.0\lib\net45\Octopus.Server.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Server.Extensibility.Authentication, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.3.0.0\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0006\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>
@@ -95,7 +92,11 @@
       <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.0.0\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0015\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0017\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0009\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0010\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Octopus.Server.Extensibility.Authentication.AzureAD.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0032\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0033\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0021\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0025\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Web/AzureADUserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Web/AzureADUserAuthenticatedAction.cs
@@ -34,5 +34,7 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD.Web
                 sleep)
         {
         }
+
+        protected override string ProviderName => AzureADAuthenticationProvider.ProviderName;
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Web/AzureADUserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Web/AzureADUserAuthenticatedAction.cs
@@ -1,5 +1,4 @@
-﻿using Octopus.Data.Storage.User;
-using Octopus.Diagnostics;
+﻿using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Configuration;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Infrastructure;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Tokens;
@@ -16,7 +15,7 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD.Web
             ILog log,
             IAzureADAuthTokenHandler authTokenHandler,
             IAzureADPrincipalToUserResourceMapper principalToUserResourceMapper,
-            IUserStore userStore,
+            IUpdateableUserStore userStore,
             IAzureADConfigurationStore configurationStore,
             IApiActionResponseCreator responseCreator,
             IAuthCookieCreator authCookieCreator,

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/Web/AzureADUserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/Web/AzureADUserAuthenticatedAction.cs
@@ -1,5 +1,6 @@
 ﻿using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Configuration;
+using Octopus.Server.Extensibility.Authentication.AzureAD.Identities;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Infrastructure;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Tokens;
 using Octopus.Server.Extensibility.Authentication.HostServices;
@@ -9,7 +10,7 @@ using Octopus.Time;
 
 namespace Octopus.Server.Extensibility.Authentication.AzureAD.Web
 {
-    public class AzureADUserAuthenticatedAction : UserAuthenticatedAction<IAzureADConfigurationStore, IAzureADAuthTokenHandler>
+    public class AzureADUserAuthenticatedAction : UserAuthenticatedAction<IAzureADConfigurationStore, IAzureADAuthTokenHandler, IAzureADIdentityCreator>
     {
         public AzureADUserAuthenticatedAction(
             ILog log,
@@ -20,7 +21,8 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD.Web
             IApiActionResponseCreator responseCreator,
             IAuthCookieCreator authCookieCreator,
             IInvalidLoginTracker loginTracker,
-            ISleep sleep) :
+            ISleep sleep,
+            IAzureADIdentityCreator identityCreator) :
             base(
                 log,
                 authTokenHandler,
@@ -30,7 +32,8 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD.Web
                 responseCreator,
                 authCookieCreator,
                 loginTracker,
-                sleep)
+                sleep,
+                identityCreator)
         {
         }
 

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0032" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0021" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0025" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
@@ -14,7 +14,7 @@
   <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0025" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0026" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0013" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0015" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0006" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0009" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
@@ -7,14 +7,14 @@
   <package id="Nancy" version="1.2.0" targetFramework="net452" />
   <package id="Nancy.Serialization.JsonNet" version="1.2.0" targetFramework="net452" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
-  <package id="Nevermore.Contracts" version="4.0.0-enh-odcm0053" targetFramework="net451" />
+  <package id="Nevermore.Contracts" version="4.0.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.1" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0026" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
@@ -3,19 +3,48 @@
   <package id="Autofac" version="3.5.2" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Logging" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.0.0" targetFramework="net452" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
   <package id="Nancy" version="1.2.0" targetFramework="net452" />
   <package id="Nancy.Serialization.JsonNet" version="1.2.0" targetFramework="net452" />
-  <package id="Nevermore.Contracts" version="1.0.1" targetFramework="net451" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
+  <package id="Nevermore.Contracts" version="4.0.0-enh-odcm0053" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="1.0.18" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0013" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="3.0.0" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0006" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net451" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.0.0" targetFramework="net452" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
+  <package id="System.IO" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
 </packages>

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0019" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0032" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0012" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0021" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0015" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0017" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0009" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0010" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.AzureAD/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0017" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0019" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0010" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0012" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/GoogleAppsApi.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/GoogleAppsApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration;
+using Octopus.Server.Extensibility.Authentication.GoogleApps.Identities;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Tokens;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Web;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect;
@@ -7,7 +8,7 @@ using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
 
 namespace Octopus.Server.Extensibility.Authentication.GoogleApps
 {
-    public class GoogleAppsApi : OpenIDConnectModule<GoogleAppsUserAuthenticationAction, IGoogleAppsConfigurationStore, GoogleAppsUserAuthenticatedAction, IGoogleAuthTokenHandler>
+    public class GoogleAppsApi : OpenIDConnectModule<GoogleAppsUserAuthenticationAction, IGoogleAppsConfigurationStore, GoogleAppsUserAuthenticatedAction, IGoogleAuthTokenHandler, IGoogleAppsIdentityCreator>
     {
         public GoogleAppsApi(
             IGoogleAppsConfigurationStore configurationStore, 

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/GoogleAppsAuthenticationProvider.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/GoogleAppsAuthenticationProvider.cs
@@ -8,11 +8,13 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps
 {
     public class GoogleAppsAuthenticationProvider : OpenIDConnectAuthenticationProvider<IGoogleAppsConfigurationStore>
     {
+        public const string ProviderName = "Google Apps";
+
         public GoogleAppsAuthenticationProvider(ILog log, IGoogleAppsConfigurationStore configurationStore) : base(log, configurationStore)
         {
         }
 
-        public override string IdentityProviderName => "Google Apps";
+        public override string IdentityProviderName => ProviderName;
 
         protected override IEnumerable<string> ReasonsWhyConfigIsIncomplete()
         {

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/GoogleAppsExtension.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/GoogleAppsExtension.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Octopus.Server.Extensibility.Authentication.Extensions;
+using Octopus.Server.Extensibility.Authentication.Extensions.Identities;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Identities;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Issuer;
@@ -57,6 +58,7 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps
             builder.RegisterType<GoogleAppsAuthenticationProvider>()
                 .As<IAuthenticationProvider>()
                 .As<IAuthenticationProviderWithGroupSupport>()
+                .As<IUseAuthenticationIdentities>()
                 .AsSelf()
                 .InstancePerDependency();
         }

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/GoogleAppsExtension.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/GoogleAppsExtension.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration;
+using Octopus.Server.Extensibility.Authentication.GoogleApps.Identities;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Issuer;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Tokens;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Web;
@@ -21,6 +22,8 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps
             base.Load(builder);
 
             builder.RegisterType<GoogleAppsConfigurationMapping>().As<IConfigurationDocumentMapper>().InstancePerDependency();
+
+            builder.RegisterType<GoogleAppsIdentityCreator>().As<IGoogleAppsIdentityCreator>().SingleInstance();
 
             builder.RegisterType<GoogleAppsConfigurationStore>()
                 .As<IGoogleAppsConfigurationStore>()

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Identities/GoogleAppsIdentityCreator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Identities/GoogleAppsIdentityCreator.cs
@@ -1,0 +1,12 @@
+﻿using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Identities;
+
+namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Identities
+{
+    public class GoogleAppsIdentityCreator : IdentityCreator, IGoogleAppsIdentityCreator
+    {
+        protected override string ProviderName => GoogleAppsAuthenticationProvider.ProviderName;
+    }
+
+    public interface IGoogleAppsIdentityCreator : IIdentityCreator
+    { }
+}

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0025\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0026\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0013\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0015\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0006\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0009\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
@@ -52,7 +52,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Nevermore.Contracts, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nevermore.Contracts.4.0.0-enh-odcm0053\lib\net451\Nevermore.Contracts.dll</HintPath>
+      <HintPath>..\packages\Nevermore.Contracts.4.0.0\lib\net451\Nevermore.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -66,8 +66,8 @@
       <HintPath>..\packages\Octopus.Configuration.1.0.10\lib\net45\Octopus.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0033\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+    <Reference Include="Octopus.Data, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Data.2.0.1\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0026\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0017\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0019\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0010\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0012\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
@@ -51,9 +51,8 @@
       <HintPath>..\packages\Nancy.Serialization.JsonNet.1.2.0\lib\net40\Nancy.Serialization.JsonNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Nevermore.Contracts, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nevermore.Contracts.1.0.1\lib\netstandard1.0\Nevermore.Contracts.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Nevermore.Contracts, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nevermore.Contracts.4.0.0-enh-odcm0053\lib\net451\Nevermore.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -67,9 +66,8 @@
       <HintPath>..\packages\Octopus.Configuration.1.0.10\lib\net45\Octopus.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Data, Version=1.0.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.1.0.18\lib\netstandard1.0\Octopus.Data.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0013\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -79,9 +77,8 @@
       <HintPath>..\packages\Octopus.Server.Extensibility.2.0.0\lib\net45\Octopus.Server.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Server.Extensibility.Authentication, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.3.0.0\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0006\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>
@@ -95,7 +92,11 @@
       <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.0.0\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0015\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0017\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0009\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0010\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0032\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0033\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0021\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0025\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Octopus.Server.Extensibility.Authentication.GoogleApps.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0019\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0032\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0012\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0021\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>
@@ -119,6 +119,7 @@
     <Compile Include="Configuration\GoogleAppsConfiguration.cs" />
     <Compile Include="Configuration\IGoogleAppsConfigurationStore.cs" />
     <Compile Include="GoogleAppsApi.cs" />
+    <Compile Include="Identities\GoogleAppsIdentityCreator.cs" />
     <Compile Include="Issuer\GoogleAppsAuthorizationEndpointUrlBuilder.cs" />
     <Compile Include="GoogleAppsExtension.cs" />
     <Compile Include="Issuer\GoogleKeyRetriever.cs" />

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Web/GoogleAppsUserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Web/GoogleAppsUserAuthenticatedAction.cs
@@ -1,5 +1,4 @@
-﻿using Octopus.Data.Storage.User;
-using Octopus.Diagnostics;
+﻿using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Tokens;
 using Octopus.Server.Extensibility.Authentication.HostServices;
@@ -12,7 +11,7 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Web
 {
     public class GoogleAppsUserAuthenticatedAction : UserAuthenticatedAction<IGoogleAppsConfigurationStore, IGoogleAuthTokenHandler>
     {
-        public GoogleAppsUserAuthenticatedAction(ILog log, IGoogleAuthTokenHandler authTokenHandler, IPrincipalToUserResourceMapper principalToUserResourceMapper, IUserStore userStore, IGoogleAppsConfigurationStore configurationStore, IApiActionResponseCreator responseCreator, IAuthCookieCreator authCookieCreator, IInvalidLoginTracker loginTracker, ISleep sleep) : base(log, authTokenHandler, principalToUserResourceMapper, userStore, configurationStore, responseCreator, authCookieCreator, loginTracker, sleep)
+        public GoogleAppsUserAuthenticatedAction(ILog log, IGoogleAuthTokenHandler authTokenHandler, IPrincipalToUserResourceMapper principalToUserResourceMapper, IUpdateableUserStore userStore, IGoogleAppsConfigurationStore configurationStore, IApiActionResponseCreator responseCreator, IAuthCookieCreator authCookieCreator, IInvalidLoginTracker loginTracker, ISleep sleep) : base(log, authTokenHandler, principalToUserResourceMapper, userStore, configurationStore, responseCreator, authCookieCreator, loginTracker, sleep)
         {
         }
 

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Web/GoogleAppsUserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Web/GoogleAppsUserAuthenticatedAction.cs
@@ -1,5 +1,6 @@
 ﻿using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration;
+using Octopus.Server.Extensibility.Authentication.GoogleApps.Identities;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Tokens;
 using Octopus.Server.Extensibility.Authentication.HostServices;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Infrastructure;
@@ -9,9 +10,28 @@ using Octopus.Time;
 
 namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Web
 {
-    public class GoogleAppsUserAuthenticatedAction : UserAuthenticatedAction<IGoogleAppsConfigurationStore, IGoogleAuthTokenHandler>
+    public class GoogleAppsUserAuthenticatedAction : UserAuthenticatedAction<IGoogleAppsConfigurationStore, IGoogleAuthTokenHandler, IGoogleAppsIdentityCreator>
     {
-        public GoogleAppsUserAuthenticatedAction(ILog log, IGoogleAuthTokenHandler authTokenHandler, IPrincipalToUserResourceMapper principalToUserResourceMapper, IUpdateableUserStore userStore, IGoogleAppsConfigurationStore configurationStore, IApiActionResponseCreator responseCreator, IAuthCookieCreator authCookieCreator, IInvalidLoginTracker loginTracker, ISleep sleep) : base(log, authTokenHandler, principalToUserResourceMapper, userStore, configurationStore, responseCreator, authCookieCreator, loginTracker, sleep)
+        public GoogleAppsUserAuthenticatedAction(ILog log,
+            IGoogleAuthTokenHandler authTokenHandler, 
+            IPrincipalToUserResourceMapper principalToUserResourceMapper, 
+            IUpdateableUserStore userStore,
+            IGoogleAppsConfigurationStore configurationStore, 
+            IApiActionResponseCreator responseCreator, 
+            IAuthCookieCreator authCookieCreator, 
+            IInvalidLoginTracker loginTracker, 
+            ISleep sleep,
+            IGoogleAppsIdentityCreator identityCreator) : base(
+                log, 
+                authTokenHandler, 
+                principalToUserResourceMapper, 
+                userStore, 
+                configurationStore, 
+                responseCreator, 
+                authCookieCreator, 
+                loginTracker, 
+                sleep,
+                identityCreator)
         {
         }
 

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Web/GoogleAppsUserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/Web/GoogleAppsUserAuthenticatedAction.cs
@@ -15,5 +15,7 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Web
         public GoogleAppsUserAuthenticatedAction(ILog log, IGoogleAuthTokenHandler authTokenHandler, IPrincipalToUserResourceMapper principalToUserResourceMapper, IUserStore userStore, IGoogleAppsConfigurationStore configurationStore, IApiActionResponseCreator responseCreator, IAuthCookieCreator authCookieCreator, IInvalidLoginTracker loginTracker, ISleep sleep) : base(log, authTokenHandler, principalToUserResourceMapper, userStore, configurationStore, responseCreator, authCookieCreator, loginTracker, sleep)
         {
         }
+
+        protected override string ProviderName => GoogleAppsAuthenticationProvider.ProviderName;
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0032" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0021" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0025" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
@@ -14,7 +14,7 @@
   <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0025" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0026" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0013" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0015" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0006" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0009" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
@@ -7,14 +7,14 @@
   <package id="Nancy" version="1.2.0" targetFramework="net452" />
   <package id="Nancy.Serialization.JsonNet" version="1.2.0" targetFramework="net452" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
-  <package id="Nevermore.Contracts" version="4.0.0-enh-odcm0053" targetFramework="net451" />
+  <package id="Nevermore.Contracts" version="4.0.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.1" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0026" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
@@ -3,19 +3,48 @@
   <package id="Autofac" version="3.5.2" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Logging" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.0.0" targetFramework="net452" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
   <package id="Nancy" version="1.2.0" targetFramework="net452" />
   <package id="Nancy.Serialization.JsonNet" version="1.2.0" targetFramework="net452" />
-  <package id="Nevermore.Contracts" version="1.0.1" targetFramework="net451" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
+  <package id="Nevermore.Contracts" version="4.0.0-enh-odcm0053" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="1.0.18" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0013" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="3.0.0" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0006" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net451" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.0.0" targetFramework="net452" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
+  <package id="System.IO" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
 </packages>

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0019" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0032" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0012" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0021" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0015" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0017" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0009" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0010" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.GoogleApps/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0017" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0019" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0010" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0012" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/Identities/OktaIdentityCreator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/Identities/OktaIdentityCreator.cs
@@ -1,0 +1,12 @@
+﻿using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Identities;
+
+namespace Octopus.Server.Extensibility.Authentication.Okta.Identities
+{
+    public class OktaIdentityCreator : IdentityCreator, IOktaIdentityCreator
+    {
+        protected override string ProviderName => OktaAuthenticationProvider.ProviderName;
+    }
+
+    public interface IOktaIdentityCreator : IIdentityCreator
+    { }
+}

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0025\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0026\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0013\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0015\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0006\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0009\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
@@ -52,7 +52,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Nevermore.Contracts, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nevermore.Contracts.4.0.0-enh-odcm0053\lib\net451\Nevermore.Contracts.dll</HintPath>
+      <HintPath>..\packages\Nevermore.Contracts.4.0.0\lib\net451\Nevermore.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -66,8 +66,8 @@
       <HintPath>..\packages\Octopus.Configuration.1.0.10\lib\net45\Octopus.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0033\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+    <Reference Include="Octopus.Data, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Data.2.0.1\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0026\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0017\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0019\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0010\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0012\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
@@ -51,9 +51,8 @@
       <HintPath>..\packages\Nancy.Serialization.JsonNet.1.2.0\lib\net40\Nancy.Serialization.JsonNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Nevermore.Contracts, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nevermore.Contracts.1.0.1\lib\netstandard1.0\Nevermore.Contracts.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Nevermore.Contracts, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nevermore.Contracts.4.0.0-enh-odcm0053\lib\net451\Nevermore.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -67,9 +66,8 @@
       <HintPath>..\packages\Octopus.Configuration.1.0.10\lib\net45\Octopus.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Data, Version=1.0.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.1.0.18\lib\netstandard1.0\Octopus.Data.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0013\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -79,9 +77,8 @@
       <HintPath>..\packages\Octopus.Server.Extensibility.2.0.0\lib\net45\Octopus.Server.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Server.Extensibility.Authentication, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.3.0.0\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0006\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>
@@ -95,7 +92,11 @@
       <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.0.0\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0015\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0017\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0009\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0010\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0032\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0033\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0021\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0025\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/Octopus.Server.Extensibility.Authentication.Okta.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0019\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0032\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0012\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0021\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>
@@ -112,6 +112,7 @@
     <Compile Include="..\Solution Items\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="Identities\OktaIdentityCreator.cs" />
     <Compile Include="OktaApi.cs" />
     <Compile Include="OktaExtension.cs" />
     <Compile Include="Configuration\OktaConfiguration.cs" />

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/OktaApi.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/OktaApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Octopus.Server.Extensibility.Authentication.Okta.Configuration;
+using Octopus.Server.Extensibility.Authentication.Okta.Identities;
 using Octopus.Server.Extensibility.Authentication.Okta.Tokens;
 using Octopus.Server.Extensibility.Authentication.Okta.Web;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect;
@@ -7,7 +8,7 @@ using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
 
 namespace Octopus.Server.Extensibility.Authentication.Okta
 {
-    public class OktaApi : OpenIDConnectModule<OktaUserAuthenticationAction, IOktaConfigurationStore, OktaUserAuthenticatedAction, IOktaAuthTokenHandler>
+    public class OktaApi : OpenIDConnectModule<OktaUserAuthenticationAction, IOktaConfigurationStore, OktaUserAuthenticatedAction, IOktaAuthTokenHandler, IOktaIdentityCreator>
     {
         public OktaApi(
             IOktaConfigurationStore configurationStore, 

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/OktaAuthenticationProvider.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/OktaAuthenticationProvider.cs
@@ -8,11 +8,13 @@ namespace Octopus.Server.Extensibility.Authentication.Okta
 {
     public class OktaAuthenticationProvider : OpenIDConnectAuthenticationProvider<IOktaConfigurationStore>
     {
+        public const string ProviderName = "Okta";
+
         public OktaAuthenticationProvider(ILog log, IOktaConfigurationStore configurationStore) : base(log, configurationStore)
         {
         }
 
-        public override string IdentityProviderName => "Okta";
+        public override string IdentityProviderName => ProviderName;
 
         protected override IEnumerable<string> ReasonsWhyConfigIsIncomplete()
         {

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/OktaExtension.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/OktaExtension.cs
@@ -5,6 +5,7 @@ using Octopus.Server.Extensibility.Authentication.Okta.Issuer;
 using Octopus.Server.Extensibility.Authentication.Okta.Tokens;
 using Octopus.Server.Extensibility.Authentication.Okta.Web;
 using Octopus.Server.Extensibility.Authentication.Extensions;
+using Octopus.Server.Extensibility.Authentication.Okta.Identities;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Certificates;
 using Octopus.Server.Extensibility.Extensions;
@@ -23,6 +24,8 @@ namespace Octopus.Server.Extensibility.Authentication.Okta
 
             builder.RegisterType<OktaPrincipalToUserResourceMapper>().As<IOktaPrincipalToUserResourceMapper>().InstancePerDependency();
             builder.RegisterType<OktaConfigurationMapping>().As<IConfigurationDocumentMapper>().InstancePerDependency();
+
+            builder.RegisterType<OktaIdentityCreator>().As<IOktaIdentityCreator>().SingleInstance();
 
             builder.RegisterType<OktaConfigurationStore>()
                 .As<IOktaConfigurationStore>()

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/OktaExtension.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/OktaExtension.cs
@@ -5,6 +5,7 @@ using Octopus.Server.Extensibility.Authentication.Okta.Issuer;
 using Octopus.Server.Extensibility.Authentication.Okta.Tokens;
 using Octopus.Server.Extensibility.Authentication.Okta.Web;
 using Octopus.Server.Extensibility.Authentication.Extensions;
+using Octopus.Server.Extensibility.Authentication.Extensions.Identities;
 using Octopus.Server.Extensibility.Authentication.Okta.Identities;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Certificates;
@@ -59,6 +60,7 @@ namespace Octopus.Server.Extensibility.Authentication.Okta
             builder.RegisterType<OktaAuthenticationProvider>()
                 .As<IAuthenticationProvider>()
                 .As<IAuthenticationProviderWithGroupSupport>()
+                .As<IUseAuthenticationIdentities>()
                 .AsSelf()
                 .InstancePerDependency();
         }

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/Web/OktaUserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/Web/OktaUserAuthenticatedAction.cs
@@ -1,5 +1,4 @@
-﻿using Octopus.Data.Storage.User;
-using Octopus.Diagnostics;
+﻿using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.Okta.Configuration;
 using Octopus.Server.Extensibility.Authentication.Okta.Infrastructure;
 using Octopus.Server.Extensibility.Authentication.Okta.Tokens;
@@ -16,7 +15,7 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Web
             ILog log,
             IOktaAuthTokenHandler authTokenHandler,
             IOktaPrincipalToUserResourceMapper principalToUserResourceMapper,
-            IUserStore userStore,
+            IUpdateableUserStore userStore,
             IOktaConfigurationStore configurationStore,
             IApiActionResponseCreator responseCreator,
             IAuthCookieCreator authCookieCreator,

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/Web/OktaUserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/Web/OktaUserAuthenticatedAction.cs
@@ -34,5 +34,7 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Web
                 sleep)
         {
         }
+
+        protected override string ProviderName => OktaAuthenticationProvider.ProviderName;
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/Web/OktaUserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/Web/OktaUserAuthenticatedAction.cs
@@ -3,13 +3,14 @@ using Octopus.Server.Extensibility.Authentication.Okta.Configuration;
 using Octopus.Server.Extensibility.Authentication.Okta.Infrastructure;
 using Octopus.Server.Extensibility.Authentication.Okta.Tokens;
 using Octopus.Server.Extensibility.Authentication.HostServices;
+using Octopus.Server.Extensibility.Authentication.Okta.Identities;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web;
 using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
 using Octopus.Time;
 
 namespace Octopus.Server.Extensibility.Authentication.Okta.Web
 {
-    public class OktaUserAuthenticatedAction : UserAuthenticatedAction<IOktaConfigurationStore, IOktaAuthTokenHandler>
+    public class OktaUserAuthenticatedAction : UserAuthenticatedAction<IOktaConfigurationStore, IOktaAuthTokenHandler, IOktaIdentityCreator>
     {
         public OktaUserAuthenticatedAction(
             ILog log,
@@ -20,7 +21,8 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Web
             IApiActionResponseCreator responseCreator,
             IAuthCookieCreator authCookieCreator,
             IInvalidLoginTracker loginTracker,
-            ISleep sleep) :
+            ISleep sleep,
+            IOktaIdentityCreator identityCreator) :
             base(
                 log,
                 authTokenHandler,
@@ -30,7 +32,8 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Web
                 responseCreator,
                 authCookieCreator,
                 loginTracker,
-                sleep)
+                sleep,
+                identityCreator)
         {
         }
 

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0032" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0021" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0025" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
@@ -14,7 +14,7 @@
   <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0025" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0026" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0013" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0015" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0006" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0009" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
@@ -7,14 +7,14 @@
   <package id="Nancy" version="1.2.0" targetFramework="net452" />
   <package id="Nancy.Serialization.JsonNet" version="1.2.0" targetFramework="net452" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
-  <package id="Nevermore.Contracts" version="4.0.0-enh-odcm0053" targetFramework="net451" />
+  <package id="Nevermore.Contracts" version="4.0.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.1" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0026" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
@@ -3,19 +3,48 @@
   <package id="Autofac" version="3.5.2" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Logging" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.0.0" targetFramework="net452" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
   <package id="Nancy" version="1.2.0" targetFramework="net452" />
   <package id="Nancy.Serialization.JsonNet" version="1.2.0" targetFramework="net452" />
-  <package id="Nevermore.Contracts" version="1.0.1" targetFramework="net451" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
+  <package id="Nevermore.Contracts" version="4.0.0-enh-odcm0053" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="1.0.18" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0013" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="3.0.0" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0006" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net451" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.0.0" targetFramework="net452" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
+  <package id="System.IO" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
 </packages>

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0019" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0032" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0012" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0021" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0015" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0017" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0009" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0010" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Okta/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net452" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0017" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0019" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0010" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0012" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Configuration/IOpenIdConnectConfigurationStore.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Configuration/IOpenIdConnectConfigurationStore.cs
@@ -28,5 +28,8 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuratio
         void SetLoginLinkLabel(string loginLinkLabel);
 
         string RedirectUri { get; }
+
+        bool GetAllowAutoUserCreation();
+        void SetAllowAutoUserCreation(bool allowAutoUserCreation);
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationStore.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationStore.cs
@@ -112,6 +112,17 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuratio
             ConfigurationStore.CreateOrUpdate<TConfiguration>(SingletonId, doc => doc.LoginLinkLabel = loginLinkLabel);
         }
 
+        public bool GetAllowAutoUserCreation()
+        {
+            var doc = ConfigurationStore.Get<TConfiguration>(SingletonId);
+            return doc?.AllowAutoUserCreation.GetValueOrDefault(true) ?? true;
+        }
+
+        public void SetAllowAutoUserCreation(bool allowAutoUserCreation)
+        {
+            ConfigurationStore.CreateOrUpdate<TConfiguration>(SingletonId, doc => doc.AllowAutoUserCreation = allowAutoUserCreation);
+        }
+
         public string RedirectUri => $"/api/users/authenticatedToken/{ConfigurationSettingsName}";
 
         public abstract string ConfigurationSetName { get; }
@@ -126,6 +137,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuratio
             yield return new ConfigurationValue($"Octopus.{ConfigurationSettingsName}.RedirectUri", RedirectUri, GetIsEnabled(), "RedirectUri");
             yield return new ConfigurationValue($"Octopus.{ConfigurationSettingsName}.NameClaimType", GetNameClaimType(), GetIsEnabled() && GetNameClaimType() != OpenIDConnectConfiguration.DefaultNameClaimType, "Name Claim Type");
             yield return new ConfigurationValue($"Octopus.{ConfigurationSettingsName}.LoginLinkLabel", GetLoginLinkLabel(), false);
+            yield return new ConfigurationValue($"Octopus.{ConfigurationSettingsName}.AllowAutoUserCreation", GetAllowAutoUserCreation().ToString(), GetIsEnabled(), "Allow auto user creation");
         }
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigureCommands.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigureCommands.cs
@@ -84,6 +84,12 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuratio
                 ConfigurationStore.Value.SetLoginLinkLabel(v);
                 Log.Info($"{ConfigurationSettingsName} LoginLinkLabel set to: {v}");
             });
+            yield return new ConfigureCommandOption($"{ConfigurationSettingsName}AllowAutoUserCreation=", $"Set {ConfigurationSettingsName} AllowAutoUserCreation.", v =>
+            {
+                var isAllowed = bool.Parse(v);
+                ConfigurationStore.Value.SetAllowAutoUserCreation(isAllowed);
+                Log.Info($"{ConfigurationSettingsName} AllowAutoUserCreation set to: {isAllowed}");
+            });
         }
 
         public void Handle(string webAuthenticationMode)

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIdConnectConfiguration.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIdConnectConfiguration.cs
@@ -38,6 +38,8 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuratio
 
         public string LoginLinkLabel { get; set; }
 
+        public bool? AllowAutoUserCreation { get; set; }
+
         public void SetId(string id)
         {
             Id = id;

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Identities/IIdentityCreator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Identities/IIdentityCreator.cs
@@ -4,6 +4,6 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Identities
 {
     public interface IIdentityCreator
     {
-        Identity Create(string email, string externalId);
+        Identity Create(string email, string displayName, string externalId);
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Identities/IIdentityCreator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Identities/IIdentityCreator.cs
@@ -1,0 +1,9 @@
+﻿using Octopus.Data.Model.User;
+
+namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Identities
+{
+    public interface IIdentityCreator
+    {
+        Identity Create(string email, string externalId);
+    }
+}

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Identities/IdentityCreator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Identities/IdentityCreator.cs
@@ -1,18 +1,19 @@
 using Octopus.Data.Model.User;
+using Octopus.Server.Extensibility.Authentication.Resources.Identities;
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Identities
 {
     public abstract class IdentityCreator : IIdentityCreator
     {
-        public const string EmailClaimType = "email";
         public const string ExternalIdClaimType = "eid";
 
         protected abstract string ProviderName { get; }
 
-        public Identity Create(string email, string externalId)
+        public Identity Create(string email, string displayName, string externalId)
         {
             return new Identity(ProviderName)
-                .WithClaim(EmailClaimType, email, true)
+                .WithClaim(ClaimDescriptor.EmailClaimType, email, true)
+                .WithClaim(ClaimDescriptor.DisplayNameClaimType, displayName, true)
                 .WithClaim(ExternalIdClaimType, externalId, true, true);
         }
     }

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Identities/IdentityCreator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Identities/IdentityCreator.cs
@@ -1,0 +1,19 @@
+using Octopus.Data.Model.User;
+
+namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Identities
+{
+    public abstract class IdentityCreator : IIdentityCreator
+    {
+        public const string EmailClaimType = "email";
+        public const string ExternalIdClaimType = "eid";
+
+        protected abstract string ProviderName { get; }
+
+        public Identity Create(string email, string externalId)
+        {
+            return new Identity(ProviderName)
+                .WithClaim(EmailClaimType, email, true)
+                .WithClaim(ExternalIdClaimType, externalId, true, true);
+        }
+    }
+}

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
@@ -54,7 +54,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Nevermore.Contracts, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nevermore.Contracts.4.0.0-enh-odcm0053\lib\net451\Nevermore.Contracts.dll</HintPath>
+      <HintPath>..\packages\Nevermore.Contracts.4.0.0\lib\net451\Nevermore.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -68,8 +68,8 @@
       <HintPath>..\packages\Octopus.Configuration.1.0.10\lib\net45\Octopus.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0033\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+    <Reference Include="Octopus.Data, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Data.2.0.1\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -80,7 +80,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0026\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
@@ -69,7 +69,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0017\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0019\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -80,7 +80,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0010\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0012\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
@@ -80,7 +80,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0025\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0026\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
@@ -69,7 +69,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0015\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0017\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -80,7 +80,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0009\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0010\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
@@ -69,7 +69,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0032\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0033\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -80,7 +80,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0021\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0025\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
@@ -69,7 +69,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0013\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0015\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -80,7 +80,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0006\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0009\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
@@ -53,9 +53,8 @@
       <HintPath>..\packages\Nancy.Serialization.JsonNet.1.2.0\lib\net40\Nancy.Serialization.JsonNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Nevermore.Contracts, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nevermore.Contracts.1.0.1\lib\netstandard1.0\Nevermore.Contracts.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Nevermore.Contracts, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nevermore.Contracts.4.0.0-enh-odcm0053\lib\net451\Nevermore.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -69,9 +68,8 @@
       <HintPath>..\packages\Octopus.Configuration.1.0.10\lib\net45\Octopus.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Data, Version=1.0.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.1.0.18\lib\netstandard1.0\Octopus.Data.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0013\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -81,9 +79,8 @@
       <HintPath>..\packages\Octopus.Server.Extensibility.2.0.0\lib\net45\Octopus.Server.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Server.Extensibility.Authentication, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.3.0.0\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0006\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>
@@ -98,7 +95,11 @@
       <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.0.0\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Octopus.Server.Extensibility.Authentication.OpenIdConnect.csproj
@@ -69,7 +69,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0019\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0032\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.11\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -80,7 +80,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Server.Extensibility.Authentication, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0012\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
+      <HintPath>..\packages\Octopus.Server.Extensibility.Authentication.4.0.0-enh-extsecgrpsch0021\lib\net45\Octopus.Server.Extensibility.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.8\lib\netstandard1.0\Octopus.Time.dll</HintPath>
@@ -117,6 +117,8 @@
     </Compile>
     <Compile Include="Certificates\KeyDetails.cs" />
     <Compile Include="Certificates\RsaDetails.cs" />
+    <Compile Include="Identities\IdentityCreator.cs" />
+    <Compile Include="Identities\IIdentityCreator.cs" />
     <Compile Include="OpenIDConnectAuthenticationProvider.cs" />
     <Compile Include="Issuer\AuthorizationEndpointUrlBuilder.cs" />
     <Compile Include="Certificates\CertificateDetails.cs" />

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/OpenIDConnectAuthenticationProvider.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/OpenIDConnectAuthenticationProvider.cs
@@ -1,12 +1,15 @@
 ﻿using System.Collections.Generic;
 using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.Extensions;
+using Octopus.Server.Extensibility.Authentication.Extensions.Identities;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Identities;
 using Octopus.Server.Extensibility.Authentication.Resources;
+using Octopus.Server.Extensibility.Authentication.Resources.Identities;
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect
 {
-    public abstract class OpenIDConnectAuthenticationProvider<TStore> : IAuthenticationProviderWithGroupSupport 
+    public abstract class OpenIDConnectAuthenticationProvider<TStore> : IAuthenticationProviderWithGroupSupport, IUseAuthenticationIdentities
         where TStore : IOpenIDConnectConfigurationStore
     {
         readonly ILog log;
@@ -67,6 +70,19 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect
         public string[] GetAuthenticationUrls()
         {
             return new[] { AuthenticateUri, ConfigurationStore.RedirectUri };
+        }
+
+        public IdentityMetadataResource GetMetadata()
+        {
+            return new IdentityMetadataResource
+            {
+                ProviderName = IdentityProviderName,
+                ClaimDescriptors = new[]
+                {
+                    new ClaimDescriptor { Type = ClaimDescriptor.DisplayNameClaimType, Label = "Display name", IsIdentifyingClaim = false},
+                    new ClaimDescriptor { Type = ClaimDescriptor.EmailClaimType, Label = "Email address", IsIdentifyingClaim = true}
+                }
+            };
         }
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/OpenIDConnectAuthenticationProvider.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/OpenIDConnectAuthenticationProvider.cs
@@ -76,7 +76,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect
         {
             return new IdentityMetadataResource
             {
-                ProviderName = IdentityProviderName,
+                IdentityProviderName = IdentityProviderName,
                 ClaimDescriptors = new[]
                 {
                     new ClaimDescriptor { Type = ClaimDescriptor.DisplayNameClaimType, Label = "Display name", IsIdentifyingClaim = false},

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/OpenIdConnectModule.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/OpenIdConnectModule.cs
@@ -1,16 +1,18 @@
 ﻿using Nancy;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Identities;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web;
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect
 {
-    public abstract class OpenIDConnectModule<TAuthenticationAction, TStore, TAuthenticatedAction, TAuthTokenHandler> : NancyModule
+    public abstract class OpenIDConnectModule<TAuthenticationAction, TStore, TAuthenticatedAction, TAuthTokenHandler, TIdentityCreator> : NancyModule
         where TStore : IOpenIDConnectConfigurationStore
         where TAuthenticationAction : UserAuthenticationAction<TStore>
         where TAuthTokenHandler : IAuthTokenHandler
-        where TAuthenticatedAction : UserAuthenticatedAction<TStore, TAuthTokenHandler>
+        where TAuthenticatedAction : UserAuthenticatedAction<TStore, TAuthTokenHandler, TIdentityCreator>
+        where TIdentityCreator : IIdentityCreator
     {
         protected OpenIDConnectModule(TStore configurationStore, IAuthenticationProvider authenticationProvider)
         {

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Web/UserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Web/UserAuthenticatedAction.cs
@@ -179,7 +179,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
         {
             var groups = principal.FindAll(ClaimTypes.Role).Select(c => c.Value).ToArray();
 
-            var user = userStore.GetByIdentity(new OAuthIdentityToMatch(ProviderName, userResource.EmailAddress, userResource.ExternalId));
+            var user = userStore.GetByIdentity(new OAuthIdentity(ProviderName, userResource.EmailAddress, userResource.ExternalId));
 
             if (user != null)
             {

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Web/UserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Web/UserAuthenticatedAction.cs
@@ -15,6 +15,7 @@ using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Identities;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Infrastructure;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
+using Octopus.Server.Extensibility.Authentication.Resources.Identities;
 using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
 using Octopus.Time;
 
@@ -196,7 +197,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
                     return new UserCreateResult(user);
                 }
 
-                identity = user.Identities.FirstOrDefault(x => x.Provider == ProviderName && x.Claims[IdentityCreator.EmailClaimType].Value == userResource.EmailAddress);
+                identity = user.Identities.FirstOrDefault(x => x.Provider == ProviderName && x.Claims[ClaimDescriptor.EmailClaimType].Value == userResource.EmailAddress);
                 if (identity != null)
                 {
                     return new UserCreateResult(userStore.UpdateIdentity(user.Id, identityToMatch));
@@ -221,7 +222,10 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
 
         Identity NewIdentity(UserResource userResource)
         {
-            return identityCreator.Create(userResource.EmailAddress, userResource.ExternalId);
+            return identityCreator.Create(
+                userResource.EmailAddress,
+                userResource.DisplayName,
+                userResource.ExternalId);
         }
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Web/UserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Web/UserAuthenticatedAction.cs
@@ -119,10 +119,10 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
                 return BadRequest("You have had too many failed login attempts in a short period of time. Please try again later.");
             }
 
-            using (var cancellationToken = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
             {
                 // Step 4b: Try to get or create a the Octopus User this external identity represents
-                var userResult = GetOrCreateUser(authenticationCandidate, principal, cancellationToken.Token);
+                var userResult = GetOrCreateUser(authenticationCandidate, principal, cts.Token);
                 if (userResult.Succeeded)
                 {
                     loginTracker.RecordSucess(authenticationCandidate.Username, context.Request.UserHostAddress);

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Web/UserAuthenticatedAction.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/Web/UserAuthenticatedAction.cs
@@ -191,13 +191,13 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
 
             if (user != null)
             {
-                var identity = user.Identities.FirstOrDefault(x => x.Provider == ProviderName && x.Claims[IdentityCreator.ExternalIdClaimType].Value == userResource.ExternalId);
+                var identity = user.Identities.FirstOrDefault(x => x.IdentityProviderName == ProviderName && x.Claims[IdentityCreator.ExternalIdClaimType].Value == userResource.ExternalId);
                 if (identity != null)
                 {
                     return new UserCreateResult(user);
                 }
 
-                identity = user.Identities.FirstOrDefault(x => x.Provider == ProviderName && x.Claims[ClaimDescriptor.EmailClaimType].Value == userResource.EmailAddress);
+                identity = user.Identities.FirstOrDefault(x => x.IdentityProviderName == ProviderName && x.Claims[ClaimDescriptor.EmailClaimType].Value == userResource.EmailAddress);
                 if (identity != null)
                 {
                     return new UserCreateResult(userStore.UpdateIdentity(user.Id, identityToMatch));
@@ -214,7 +214,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
                 userResource.DisplayName, 
                 userResource.EmailAddress,
                 cancellationToken,
-                new ProviderUserGroups { ProviderName = ProviderName, GroupIds = groups },
+                new ProviderUserGroups { IdentityProviderName = ProviderName, GroupIds = groups },
                 new[] { identityToMatch });
 
             return userResult;

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0013" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0015" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0006" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0009" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0019" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0032" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0012" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0021" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
@@ -14,7 +14,7 @@
   <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0025" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0026" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
@@ -3,19 +3,48 @@
   <package id="Autofac" version="3.5.2" targetFramework="net451" />
   <package id="Microsoft.IdentityModel.Logging" version="1.0.0" targetFramework="net451" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.0.0" targetFramework="net451" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
   <package id="Nancy" version="1.2.0" targetFramework="net451" />
   <package id="Nancy.Serialization.JsonNet" version="1.2.0" targetFramework="net451" />
-  <package id="Nevermore.Contracts" version="1.0.1" targetFramework="net451" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
+  <package id="Nevermore.Contracts" version="4.0.0-enh-odcm0053" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="1.0.18" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0013" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="3.0.0" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0006" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net451" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net451" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.0.0" targetFramework="net451" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net451" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net451" />
+  <package id="System.IO" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
 </packages>

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0015" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0017" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0009" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0010" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0032" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0021" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0025" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
@@ -7,14 +7,14 @@
   <package id="Nancy" version="1.2.0" targetFramework="net451" />
   <package id="Nancy.Serialization.JsonNet" version="1.2.0" targetFramework="net451" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
-  <package id="Nevermore.Contracts" version="4.0.0-enh-odcm0053" targetFramework="net451" />
+  <package id="Nevermore.Contracts" version="4.0.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.1" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0026" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.OpenIDConnect/packages.config
@@ -11,10 +11,10 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="Octopus.Configuration" version="1.0.10" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0017" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0019" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.11" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0010" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility.Authentication" version="4.0.0-enh-extsecgrpsch0012" targetFramework="net451" />
   <package id="Octopus.Time" version="1.0.8" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
@@ -48,8 +48,8 @@
     <Reference Include="Nancy.Serialization.JsonNet, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Nancy.Serialization.JsonNet.1.2.0\lib\net40\Nancy.Serialization.JsonNet.dll</HintPath>
     </Reference>
-    <Reference Include="Nevermore.Contracts, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nevermore.Contracts.1.0.1\lib\netstandard1.0\Nevermore.Contracts.dll</HintPath>
+    <Reference Include="Nevermore.Contracts, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nevermore.Contracts.4.0.0-enh-odcm0053\lib\net451\Nevermore.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -63,8 +63,8 @@
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Octopus.Data, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.1.0.8\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+    <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0013\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.12\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
@@ -77,6 +77,11 @@
     <Reference Include="System.Core" />
     <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.0.0.127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.0.0\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.Xml.Linq" />

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
@@ -64,7 +64,7 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0015\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0017\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.12\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
@@ -49,7 +49,7 @@
       <HintPath>..\packages\Nancy.Serialization.JsonNet.1.2.0\lib\net40\Nancy.Serialization.JsonNet.dll</HintPath>
     </Reference>
     <Reference Include="Nevermore.Contracts, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nevermore.Contracts.4.0.0-enh-odcm0053\lib\net451\Nevermore.Contracts.dll</HintPath>
+      <HintPath>..\packages\Nevermore.Contracts.4.0.0\lib\net451\Nevermore.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -63,8 +63,8 @@
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0033\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+    <Reference Include="Octopus.Data, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Data.2.0.1\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.12\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
@@ -64,7 +64,7 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0017\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0019\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.12\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
@@ -64,7 +64,7 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0019\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0032\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.12\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
@@ -64,7 +64,7 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0032\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0033\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.12\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/Octopus.Server.Extensibility.Authentication.Tests.csproj
@@ -64,7 +64,7 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0013\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+      <HintPath>..\packages\Octopus.Data.2.0.0-enh-extsecgrpsch0015\lib\netstandard1.0\Octopus.Data.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Diagnostics, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.12\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
@@ -8,12 +8,12 @@
   <package id="Nancy" version="1.4.1" targetFramework="net451" />
   <package id="Nancy.Serialization.JsonNet" version="1.2.0" targetFramework="net451" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
-  <package id="Nevermore.Contracts" version="4.0.0-enh-odcm0053" targetFramework="net451" />
+  <package id="Nevermore.Contracts" version="4.0.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.1" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.12" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.2" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
@@ -13,7 +13,7 @@
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0013" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0015" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.12" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.2" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
@@ -13,7 +13,7 @@
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0032" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0033" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.12" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.2" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
@@ -13,7 +13,7 @@
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0015" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0017" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.12" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.2" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
@@ -13,7 +13,7 @@
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0017" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0019" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.12" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.2" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
@@ -4,18 +4,47 @@
   <package id="JWT" version="3.0.1" targetFramework="net451" />
   <package id="Microsoft.IdentityModel.Logging" version="1.0.0" targetFramework="net451" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.0.0" targetFramework="net451" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
   <package id="Nancy" version="1.4.1" targetFramework="net451" />
   <package id="Nancy.Serialization.JsonNet" version="1.2.0" targetFramework="net451" />
-  <package id="Nevermore.Contracts" version="1.0.1" targetFramework="net451" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
+  <package id="Nevermore.Contracts" version="4.0.0-enh-odcm0053" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
-  <package id="Octopus.Data" version="1.0.8" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0013" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.12" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.2" targetFramework="net451" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net451" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net451" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.0.0" targetFramework="net451" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net451" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net451" />
+  <package id="System.IO" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
 </packages>

--- a/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication.Tests/packages.config
@@ -13,7 +13,7 @@
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
-  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0019" targetFramework="net451" />
+  <package id="Octopus.Data" version="2.0.0-enh-extsecgrpsch0032" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.12" targetFramework="net451" />
   <package id="Octopus.Server.Extensibility" version="2.0.2" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />


### PR DESCRIPTION
Added support for identities and the other things related to security groups being checked on a schedule etc.

Allow admin to enable/disable auto user creation on a per auth provider basis. I.e. AAD, GoogleApp and Okta can all be enabled/disabled independently.