### PR TITLE
fixed AzureAD and Okta key retriever registrations and made the Token…

### DIFF
--- a/source/Server.Extensibility.Authentication.AzureAD/AzureADExtension.cs
+++ b/source/Server.Extensibility.Authentication.AzureAD/AzureADExtension.cs
@@ -54,7 +54,7 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD
 
             // These are important as Singletons because they cache X509 certificates for performance
             builder.RegisterType<DefaultKeyJsonParser>().As<IKeyJsonParser>().SingleInstance();
-            builder.RegisterType<AzureADKeyRetriever>().As<IKeyRetriever>().SingleInstance();
+            builder.RegisterType<AzureADKeyRetriever>().As<IAzureADKeyRetriever>().SingleInstance();
 
             builder.RegisterType<AzureADStaticContentFolders>().As<IContributesStaticContentFolders>().InstancePerDependency();
 

--- a/source/Server.Extensibility.Authentication.AzureAD/Issuer/AzureADKeyRetriever.cs
+++ b/source/Server.Extensibility.Authentication.AzureAD/Issuer/AzureADKeyRetriever.cs
@@ -1,11 +1,12 @@
-﻿using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
+﻿using Octopus.Diagnostics;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Configuration;
 
 namespace Octopus.Server.Extensibility.Authentication.AzureAD.Issuer
 {
     public class AzureADKeyRetriever : KeyRetriever<IAzureADConfigurationStore, IKeyJsonParser>, IAzureADKeyRetriever
     {
-        public AzureADKeyRetriever(IAzureADConfigurationStore configurationStore, IKeyJsonParser keyParser) : base(configurationStore, keyParser)
+        public AzureADKeyRetriever(IAzureADConfigurationStore configurationStore, IKeyJsonParser keyParser, ILog log) : base(configurationStore, keyParser, log)
         {
         }
     }

--- a/source/Server.Extensibility.Authentication.AzureAD/Tokens/AzureADAuthTokenHandler.cs
+++ b/source/Server.Extensibility.Authentication.AzureAD/Tokens/AzureADAuthTokenHandler.cs
@@ -1,16 +1,15 @@
 ﻿using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Configuration;
 using Microsoft.IdentityModel.Tokens;
-using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
-using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Tokens;
+using Octopus.Server.Extensibility.Authentication.AzureAD.Issuer;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
 
 namespace Octopus.Server.Extensibility.Authentication.AzureAD.Tokens
 {
-    public class AzureADAuthTokenHandler : OpenIDConnectAuthTokenHandler<IAzureADConfigurationStore, IKeyRetriever>, IAzureADAuthTokenHandler
+    public class AzureADAuthTokenHandler : OpenIDConnectAuthTokenHandler<IAzureADConfigurationStore, IAzureADKeyRetriever>, IAzureADAuthTokenHandler
     {
-        public AzureADAuthTokenHandler(ILog log, IAzureADConfigurationStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
+        public AzureADAuthTokenHandler(ILog log, IAzureADConfigurationStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IAzureADKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
         {
         }
 

--- a/source/Server.Extensibility.Authentication.GoogleApps/Issuer/GoogleKeyRetriever.cs
+++ b/source/Server.Extensibility.Authentication.GoogleApps/Issuer/GoogleKeyRetriever.cs
@@ -1,11 +1,12 @@
-﻿using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
+﻿using Octopus.Diagnostics;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
 using Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration;
 
 namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Issuer
 {
     public class GoogleKeyRetriever : KeyRetriever<IGoogleAppsConfigurationStore, IKeyJsonParser>, IGoogleKeyRetriever
     {
-        public GoogleKeyRetriever(IGoogleAppsConfigurationStore configurationStore, IKeyJsonParser keyParser) : base(configurationStore, keyParser)
+        public GoogleKeyRetriever(IGoogleAppsConfigurationStore configurationStore, IKeyJsonParser keyParser, ILog log) : base(configurationStore, keyParser, log)
         {
         }
     }

--- a/source/Server.Extensibility.Authentication.Okta/Issuer/OktaKeyRetriever.cs
+++ b/source/Server.Extensibility.Authentication.Okta/Issuer/OktaKeyRetriever.cs
@@ -1,11 +1,12 @@
-﻿using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
+﻿using Octopus.Diagnostics;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
 using Octopus.Server.Extensibility.Authentication.Okta.Configuration;
 
 namespace Octopus.Server.Extensibility.Authentication.Okta.Issuer
 {
     public class OktaKeyRetriever : KeyRetriever<IOktaConfigurationStore, IKeyJsonParser>, IOktaKeyRetriever
     {
-        public OktaKeyRetriever(IOktaConfigurationStore configurationStore, IKeyJsonParser keyParser) : base(configurationStore, keyParser)
+        public OktaKeyRetriever(IOktaConfigurationStore configurationStore, IKeyJsonParser keyParser, ILog log) : base(configurationStore, keyParser, log)
         {
         }
     }

--- a/source/Server.Extensibility.Authentication.Okta/OktaExtension.cs
+++ b/source/Server.Extensibility.Authentication.Okta/OktaExtension.cs
@@ -54,7 +54,7 @@ namespace Octopus.Server.Extensibility.Authentication.Okta
 
             // These are important as Singletons because they cache X509 certificates for performance
             builder.RegisterType<DefaultKeyJsonParser>().As<IKeyJsonParser>().SingleInstance();
-            builder.RegisterType<OktaKeyRetriever>().As<IKeyRetriever>().SingleInstance();
+            builder.RegisterType<OktaKeyRetriever>().As<IOktaKeyRetriever>().SingleInstance();
 
             builder.RegisterType<OktaStaticContentFolders>().As<IContributesStaticContentFolders>().InstancePerDependency();
 

--- a/source/Server.Extensibility.Authentication.Okta/Tokens/OktaAuthTokenHandler.cs
+++ b/source/Server.Extensibility.Authentication.Okta/Tokens/OktaAuthTokenHandler.cs
@@ -1,15 +1,15 @@
 ﻿using Microsoft.IdentityModel.Tokens;
 using Octopus.Diagnostics;
-using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
 using Octopus.Server.Extensibility.Authentication.Okta.Configuration;
+using Octopus.Server.Extensibility.Authentication.Okta.Issuer;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
 
 namespace Octopus.Server.Extensibility.Authentication.Okta.Tokens
 {
-    public class OktaAuthTokenHandler : OpenIDConnectAuthTokenHandler<IOktaConfigurationStore, IKeyRetriever>, IOktaAuthTokenHandler
+    public class OktaAuthTokenHandler : OpenIDConnectAuthTokenHandler<IOktaConfigurationStore, IOktaKeyRetriever>, IOktaAuthTokenHandler
     {
-        public OktaAuthTokenHandler(ILog log, IOktaConfigurationStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
+        public OktaAuthTokenHandler(ILog log, IOktaConfigurationStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IOktaKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
         {
         }
 


### PR DESCRIPTION
…Handlers expect the more specific interface.

This addresses the issue where the provider would sometimes get key signature errors, caused because it would resolve the wrong key retriever and then default to looking at the wrong Url for the keys. The internal retry would usually sort this out, but but the signature error would get logged in the meantime.

Relates to OctopusDeploy/issues#4312