### PR TITLE
Fix group claims handling

### DIFF
--- a/source/Node.Extensibility.Authentication.OpenIDConnect/Configuration/IOpenIDConnectConfigurationWithRoleStore.cs
+++ b/source/Node.Extensibility.Authentication.OpenIDConnect/Configuration/IOpenIDConnectConfigurationWithRoleStore.cs
@@ -1,0 +1,15 @@
+﻿using Nevermore.Contracts;
+
+namespace Octopus.Node.Extensibility.Authentication.OpenIDConnect.Configuration
+{
+    public interface IOpenIDConnectConfigurationWithRoleStore<TConfiguration> : IOpenIDConnectConfigurationStore<TConfiguration>, IOpenIDConnectConfigurationWithRoleStore
+        where TConfiguration : OpenIDConnectConfigurationWithRole, IId, new()
+    {
+    }
+
+    public interface IOpenIDConnectConfigurationWithRoleStore : IOpenIDConnectConfigurationStore
+    {
+        string GetRoleClaimType();
+        void SetRoleClaimType(string roleClaimType);
+    }
+}

--- a/source/Node.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationWithRole.cs
+++ b/source/Node.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationWithRole.cs
@@ -1,0 +1,15 @@
+﻿namespace Octopus.Node.Extensibility.Authentication.OpenIDConnect.Configuration
+{
+    public class OpenIDConnectConfigurationWithRole : OpenIDConnectConfiguration
+    {
+        public OpenIDConnectConfigurationWithRole()
+        {
+        }
+
+        public OpenIDConnectConfigurationWithRole(string name, string author, string configurationSchemaVersion) : base(name, author, configurationSchemaVersion)
+        {
+        }
+
+        public string RoleClaimType { get; set; }
+    }
+}

--- a/source/Node.Extensibility.Authentication.OpenIDConnect/Issuer/AuthorizationEndpointUrlBuilder.cs
+++ b/source/Node.Extensibility.Authentication.OpenIDConnect/Issuer/AuthorizationEndpointUrlBuilder.cs
@@ -16,6 +16,9 @@ namespace Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer
             this.urlEncoder = urlEncoder;
         }
 
+        protected virtual string ResponseType => OpenIDConnectConfiguration.DefaultResponseType;
+        protected virtual string ResponseMode => OpenIDConnectConfiguration.DefaultResponseMode;
+
         public virtual string Build(string requestDirectoryPath, IssuerConfiguration issuerConfiguration, string nonce, string state)
         {
             if (issuerConfiguration == null)
@@ -24,8 +27,8 @@ namespace Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer
             var issuerEndpoint = issuerConfiguration.AuthorizationEndpoint;
             var clientId = ConfigurationStore.GetClientId();
             var scope = ConfigurationStore.GetScope();
-            var responseType = OpenIDConnectConfiguration.DefaultResponseType;
-            var responseMode = OpenIDConnectConfiguration.DefaultResponseMode;
+            var responseType = ResponseType;
+            var responseMode = ResponseMode;
             var redirectUri = requestDirectoryPath.Trim('/') + ConfigurationStore.RedirectUri;
 
             var urlPathEncode = urlEncoder.UrlEncode(state);

--- a/source/Node.Extensibility.Authentication.OpenIDConnect/Tokens/AuthTokenHandler.cs
+++ b/source/Node.Extensibility.Authentication.OpenIDConnect/Tokens/AuthTokenHandler.cs
@@ -84,7 +84,7 @@ namespace Octopus.Node.Extensibility.Authentication.OpenIDConnect.Tokens
             DoIssuerSpecificClaimsValidation(principal, out error);
 
             if (string.IsNullOrWhiteSpace(error))
-                return new ClaimsPrincipleContainer(principal);
+                return new ClaimsPrincipleContainer(principal, GetProviderRoleIds(principal));
 
             return new ClaimsPrincipleContainer(error);
         }
@@ -97,5 +97,9 @@ namespace Octopus.Node.Extensibility.Authentication.OpenIDConnect.Tokens
             error = string.Empty;
         }
 
+        protected virtual string[] GetProviderRoleIds(ClaimsPrincipal principal)
+        {
+            return new string[0];
+        }
     }
 }

--- a/source/Node.Extensibility.Authentication.OpenIDConnect/Tokens/ClaimsPrincipleContainer.cs
+++ b/source/Node.Extensibility.Authentication.OpenIDConnect/Tokens/ClaimsPrincipleContainer.cs
@@ -6,14 +6,20 @@ namespace Octopus.Node.Extensibility.Authentication.OpenIDConnect.Tokens
     {
         public ClaimsPrincipleContainer(string error)
         {
-            this.error = error;
+            this.Error = error;
         }
-        public ClaimsPrincipleContainer(ClaimsPrincipal principal)
+        public ClaimsPrincipleContainer(ClaimsPrincipal principal, string[] externalRoleIds)
         {
-            this.principal = principal;
+            this.Principal = principal;
+            ExternalRoleIds = externalRoleIds;
         }
 
-        public string error { get; private set; }
-        public ClaimsPrincipal principal { get; private set; }
+        public string Error { get; private set; }
+        public ClaimsPrincipal Principal { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the external Role/Group Ids
+        /// </summary>
+        public string[] ExternalRoleIds { get; private set; }
     }
 }

--- a/source/Node.Extensibility.Authentication.Tests/Node.Extensibility.Authentication.Tests.csproj
+++ b/source/Node.Extensibility.Authentication.Tests/Node.Extensibility.Authentication.Tests.csproj
@@ -107,7 +107,10 @@
     </Compile>
     <Compile Include="Helpers\RS256AlgorithmRsaOnly.cs" />
     <Compile Include="OpenIdConnect\Tokens\CustomOpenIDConnectAuthTokenHandler.cs" />
+    <Compile Include="OpenIdConnect\Tokens\CustomOpenIDConnectWithRoleAuthTokenHandler.cs" />
     <Compile Include="OpenIdConnect\Tokens\OpenIDConnectAuthTokenHandlerFixture.cs" />
+    <Compile Include="OpenIdConnect\Tokens\OpenIDConnectWithRolesAuthTokenHandlerFixture.cs" />
+    <Compile Include="OpenIdConnect\Tokens\OpenIDFixtureBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/CustomOpenIDConnectAuthTokenHandler.cs
+++ b/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/CustomOpenIDConnectAuthTokenHandler.cs
@@ -13,5 +13,4 @@ namespace Node.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
             
         }
     }
-
 }

--- a/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/CustomOpenIDConnectWithRoleAuthTokenHandler.cs
+++ b/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/CustomOpenIDConnectWithRoleAuthTokenHandler.cs
@@ -1,0 +1,16 @@
+﻿using Octopus.Diagnostics;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Configuration;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
+
+namespace Node.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
+{
+    public class CustomOpenIDConnectWithRoleAuthTokenHandler : OpenIDConnectAuthTokenWithRolesHandler<IOpenIDConnectConfigurationWithRoleStore, IKeyRetriever>
+    { 
+        public CustomOpenIDConnectWithRoleAuthTokenHandler(ILog log, IOpenIDConnectConfigurationWithRoleStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
+        {
+            
+        }
+    }
+}

--- a/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/OpenIDConnectAuthTokenHandlerFixture.cs
+++ b/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/OpenIDConnectAuthTokenHandlerFixture.cs
@@ -76,11 +76,11 @@ namespace Node.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
 
             // Assert
             Assert.IsNotNull(result);
-            Assert.IsNullOrEmpty(result.error);
-            Assert.IsNotNull(result.principal);
+            Assert.IsNullOrEmpty(result.Error);
+            Assert.IsNotNull(result.Principal);
             Assert.AreEqual("/state/", state);
 
-            AssertClaims(result.principal);
+            AssertClaims(result.Principal);
 
             configurationStore.Received().GetIssuer();
             configurationStore.Received().GetClientId();
@@ -124,11 +124,11 @@ namespace Node.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
 
             // Assert
             Assert.IsNotNull(result);
-            Assert.IsNullOrEmpty(result.error);
-            Assert.IsNotNull(result.principal);
+            Assert.IsNullOrEmpty(result.Error);
+            Assert.IsNotNull(result.Principal);
             Assert.AreEqual("/state/", state);
 
-            AssertClaims(result.principal);
+            AssertClaims(result.Principal);
 
             configurationStore.Received().GetIssuer();
             configurationStore.Received().GetClientId();

--- a/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/OpenIDConnectWithRolesAuthTokenHandlerFixture.cs
+++ b/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/OpenIDConnectWithRolesAuthTokenHandlerFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Tokens;
 using Nancy;
@@ -12,23 +13,23 @@ using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
 namespace Node.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
 {
     [TestFixture]
-    public class OpenIDConnectAuthTokenHandlerFixture : OpenIDFixtureBase
+    public class OpenIDConnectWithRolesAuthTokenHandlerFixture : OpenIDFixtureBase
     {
         ILog log;
-        IOpenIDConnectConfigurationStore configurationStore;
+        IOpenIDConnectConfigurationWithRoleStore configurationStore;
         IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer;
         IKeyRetriever keyRetriever;
-        CustomOpenIDConnectAuthTokenHandler target;
+        CustomOpenIDConnectWithRoleAuthTokenHandler target;
 
         [SetUp]
         public void SetUp()
         {
             log = Substitute.For<ILog>();
-            configurationStore = Substitute.For<IOpenIDConnectConfigurationStore>();
+            configurationStore = Substitute.For<IOpenIDConnectConfigurationWithRoleStore>();
             identityProviderConfigDiscoverer = Substitute.For<IIdentityProviderConfigDiscoverer>();
             keyRetriever = Substitute.For<IKeyRetriever>();
 
-            target = new CustomOpenIDConnectAuthTokenHandler(
+            target = new CustomOpenIDConnectWithRoleAuthTokenHandler(
                 log,
                 configurationStore,
                 identityProviderConfigDiscoverer,
@@ -36,11 +37,11 @@ namespace Node.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
         }
 
         [Test]
-        public async void ShouldReturnPrincipalWhenValidTokenReceived()
+        public async void ShouldReturnRolesFromToken()
         {
             // Arrange
             RsaSecurityKey rsaSecurityKeyPublic;
-            var token = CreateToken(KeyId, out rsaSecurityKeyPublic);
+            var token = CreateToken(KeyId, out rsaSecurityKeyPublic, roleIds: new[] {"octoTesters"});
             var issuerConfig = new IssuerConfiguration() {Issuer = DefaultIssuer };
             var key = new Dictionary<string, AsymmetricSecurityKey>() { { KeyId, rsaSecurityKeyPublic } };
 
@@ -48,6 +49,7 @@ namespace Node.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
 
             configurationStore.GetIssuer().Returns(DefaultIssuer);
             configurationStore.GetClientId().Returns(DefaultClientId);
+            configurationStore.GetRoleClaimType().Returns("roles");
 
             identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
                 .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
@@ -62,115 +64,25 @@ namespace Node.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
             // Assert
             Assert.IsNotNull(result);
             Assert.IsNullOrEmpty(result.Error);
-            Assert.IsNotNull(result.Principal);
-            Assert.AreEqual("/state/", state);
+            Assert.IsNotNull(result.ExternalGroupIds);
 
-            AssertClaims(result.Principal);
-
-            configurationStore.Received().GetIssuer();
-            configurationStore.Received().GetClientId();
-            Received.InOrder(async () => { await keyRetriever.GetKeysAsync(issuerConfig, false); });
-
-        }
-
-
-        [Test]
-        public async void ShouldRetryWhenInvalidKeyDetected()
-        {
-            // Arrange
-            RsaSecurityKey rsaSecurityKeyStale;
-            RsaSecurityKey rsaSecurityKeyCurrent;
-
-            var token = CreateToken("99a8e79fba13856b4159f96e9c9ea6d5", out rsaSecurityKeyStale);
-            token = CreateToken(KeyId, out rsaSecurityKeyCurrent);
-            var issuerConfig = new IssuerConfiguration() { Issuer = DefaultIssuer };
-            var key = new Dictionary<string, AsymmetricSecurityKey>() { { KeyId, rsaSecurityKeyCurrent } };
-            var staleKey = new Dictionary<string, AsymmetricSecurityKey>() { { "99a8e79fba13856b4159f96e9c9ea6d5", rsaSecurityKeyStale } };
-
-            var request = CreateRequest(token);
-
-            configurationStore.GetIssuer().Returns(DefaultIssuer);
-            configurationStore.GetClientId().Returns(DefaultClientId);
-
-            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
-                .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
-
-            // On first call to keyRetriever return invalid (stale) key
-            keyRetriever.GetKeysAsync(issuerConfig, false)
-                .Returns(Task.FromResult<IDictionary<string, AsymmetricSecurityKey>>(staleKey));
-
-            // On second call return the new valid key
-            keyRetriever.GetKeysAsync(issuerConfig, true)
-                .Returns(Task.FromResult<IDictionary<string, AsymmetricSecurityKey>>(key));
-
-            // Act
-            string state;
-            var result = await target.GetPrincipalAsync(((DynamicDictionary)request.Form).ToDictionary(), out state);
-
-            // Assert
-            Assert.IsNotNull(result);
-            Assert.IsNullOrEmpty(result.Error);
-            Assert.IsNotNull(result.Principal);
-            Assert.AreEqual("/state/", state);
-
-            AssertClaims(result.Principal);
-
-            configurationStore.Received().GetIssuer();
-            configurationStore.Received().GetClientId();
-
-            Received.InOrder(async () => { await keyRetriever.GetKeysAsync(issuerConfig, false); });
-            Received.InOrder(async () => { await keyRetriever.GetKeysAsync(issuerConfig, true); });
-        }
-
-
-        [Test]
-        [ExpectedException(typeof(SecurityTokenInvalidSignatureException))]
-        public async void ShouldThrowWhenInvalidKeyDetectedTwice()
-        {
-            // Arrange
-            RsaSecurityKey rsaSecurityKeyStale;
-            RsaSecurityKey rsaSecurityKeyCurrent;
-
-            var token = CreateToken("99a8e79fba13856b4159f96e9c9ea6d5", out rsaSecurityKeyStale);
-            token = CreateToken(KeyId, out rsaSecurityKeyCurrent);
-            var issuerConfig = new IssuerConfiguration() { Issuer = DefaultIssuer };
-            var staleKey = new Dictionary<string, AsymmetricSecurityKey>() { { "99a8e79fba13856b4159f96e9c9ea6d5", rsaSecurityKeyStale } };
-
-            var request = CreateRequest(token);
-
-            configurationStore.GetIssuer().Returns(DefaultIssuer);
-            configurationStore.GetClientId().Returns(DefaultClientId);
-
-            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
-                .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
-
-            // set keyRetriever to always return invalid (stale) key
-            keyRetriever.GetKeysAsync(issuerConfig)
-                .ReturnsForAnyArgs(Task.FromResult<IDictionary<string, AsymmetricSecurityKey>>(staleKey));
-
-            // Act
-            string state;
-            var result = await target.GetPrincipalAsync(((DynamicDictionary)request.Form).ToDictionary(), out state);
-
-            // Expect Exception Thrown
-
+            Assert.IsNotNullOrEmpty(result.ExternalGroupIds.SingleOrDefault(x => x == "octoTesters"));
         }
 
         [Test]
-        [TestCase("https://someotherdomain.com", DefaultClientId, Description = "Invalid Issuer", ExpectedException = typeof(SecurityTokenInvalidIssuerException))]
-        [TestCase(DefaultIssuer, "Another Client", Description = "Invalid ClientId", ExpectedException = typeof(SecurityTokenInvalidAudienceException))]
-        public async void ShouldThrowWhenInvalidTokenDetected(string issuer, string clientId)
+        public async void ShouldReturnGroupsFromToken()
         {
             // Arrange
             RsaSecurityKey rsaSecurityKeyPublic;
-            var token = CreateToken(KeyId, out rsaSecurityKeyPublic, issuer: issuer, clientId: clientId);
-            var issuerConfig = new IssuerConfiguration() { Issuer = DefaultIssuer };
+            var token = CreateToken(KeyId, out rsaSecurityKeyPublic, groupIds: new[] {"octoTesters"});
+            var issuerConfig = new IssuerConfiguration() {Issuer = DefaultIssuer };
             var key = new Dictionary<string, AsymmetricSecurityKey>() { { KeyId, rsaSecurityKeyPublic } };
 
             var request = CreateRequest(token);
 
             configurationStore.GetIssuer().Returns(DefaultIssuer);
             configurationStore.GetClientId().Returns(DefaultClientId);
+            configurationStore.GetRoleClaimType().Returns("groups");
 
             identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
                 .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
@@ -182,8 +94,79 @@ namespace Node.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
             string state;
             var result = await target.GetPrincipalAsync(((DynamicDictionary)request.Form).ToDictionary(), out state);
 
-            // Expect Exception Thrown
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNullOrEmpty(result.Error);
+            Assert.IsNotNull(result.ExternalGroupIds);
 
+            Assert.IsNotNullOrEmpty(result.ExternalGroupIds.SingleOrDefault(x => x == "octoTesters"));
+        }
+
+        [Test]
+        public async void ShouldReturnNoRolesWhenOnlyGroupsAreInToken()
+        {
+            // Arrange
+            RsaSecurityKey rsaSecurityKeyPublic;
+            var token = CreateToken(KeyId, out rsaSecurityKeyPublic, groupIds: new[] {"octoTesters"});
+            var issuerConfig = new IssuerConfiguration() {Issuer = DefaultIssuer };
+            var key = new Dictionary<string, AsymmetricSecurityKey>() { { KeyId, rsaSecurityKeyPublic } };
+
+            var request = CreateRequest(token);
+
+            configurationStore.GetIssuer().Returns(DefaultIssuer);
+            configurationStore.GetClientId().Returns(DefaultClientId);
+            configurationStore.GetRoleClaimType().Returns("roles");
+
+            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+                .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
+
+            keyRetriever.GetKeysAsync(issuerConfig, false)
+                .Returns(Task.FromResult<IDictionary<string, AsymmetricSecurityKey>>(key));
+
+            // Act
+            string state;
+            var result = await target.GetPrincipalAsync(((DynamicDictionary)request.Form).ToDictionary(), out state);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNullOrEmpty(result.Error);
+            Assert.IsNotNull(result.ExternalGroupIds);
+
+            Assert.IsEmpty(result.ExternalGroupIds);
+        }
+
+        [Test]
+        public async void ShouldReturnRolesAndGroupsWhenBothAreInToken()
+        {
+            // Arrange
+            RsaSecurityKey rsaSecurityKeyPublic;
+            var token = CreateToken(KeyId, out rsaSecurityKeyPublic, roleIds: new[] {"octoTestersRole"}, groupIds: new[] {"octoTestersGroup"});
+            var issuerConfig = new IssuerConfiguration() {Issuer = DefaultIssuer };
+            var key = new Dictionary<string, AsymmetricSecurityKey>() { { KeyId, rsaSecurityKeyPublic } };
+
+            var request = CreateRequest(token);
+
+            configurationStore.GetIssuer().Returns(DefaultIssuer);
+            configurationStore.GetClientId().Returns(DefaultClientId);
+            configurationStore.GetRoleClaimType().Returns("groups");
+
+            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+                .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
+
+            keyRetriever.GetKeysAsync(issuerConfig, false)
+                .Returns(Task.FromResult<IDictionary<string, AsymmetricSecurityKey>>(key));
+
+            // Act
+            string state;
+            var result = await target.GetPrincipalAsync(((DynamicDictionary)request.Form).ToDictionary(), out state);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNullOrEmpty(result.Error);
+            Assert.IsNotNull(result.ExternalGroupIds);
+
+            Assert.IsNotNullOrEmpty(result.ExternalGroupIds.SingleOrDefault(x => x == "octoTestersRole"));
+            Assert.IsNotNullOrEmpty(result.ExternalGroupIds.SingleOrDefault(x => x == "octoTestersGroup"));
         }
     }
 }

--- a/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/OpenIDFixtureBase.cs
+++ b/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/OpenIDFixtureBase.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using JWT;
+using JWT.Serializers;
+using Microsoft.IdentityModel.Tokens;
+using Nancy;
+using Node.Extensibility.Authentication.Tests.Helpers;
+using NUnit.Framework;
+
+namespace Node.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
+{
+    public class OpenIDFixtureBase
+    {
+        protected const string DefaultIssuer = "https://somedomain.com/";
+        protected const string DefaultClientId = "Octopus Deploy";
+        protected const string DefaultSubject = "12345";
+        protected const string DefaultName = "bob";
+        protected const string DefaultEmail = "bob@somedomain.com";
+
+        protected const string KeyId = "88a8e79fba13856b4159f96e9c9ea6d5";
+        protected const string Nonce = "";
+
+        protected Request CreateRequest(string token)
+        {
+            var request = new Request("POST", DefaultIssuer);
+            request.Form["access_token"] = null;
+            request.Form["id_token"] = token;
+            request.Form["state"] = "/state/";
+            return request;
+        }
+
+        protected string CreateToken(
+            string keyId,
+            out RsaSecurityKey key,
+            string issuer = DefaultIssuer,
+            string clientId = DefaultClientId,
+            string nonce = Nonce,
+            string subject = DefaultSubject,
+            string name = DefaultName,
+            string email = DefaultEmail,
+            string[] roleIds = null,
+            string[] groupIds = null)
+        {
+            var epoch = new DateTime(1970, 1, 1);
+            var now = Math.Round((DateTime.Now - epoch).TotalSeconds);
+            var exp = now + 36000;
+
+            var payload = new Dictionary<string, object>
+            {
+                { "aud", clientId },
+                { "iss", issuer },
+                { "exp", exp },
+                { "iat", now },
+                { "nonce", nonce },
+                { "sub", subject},
+                { "name", name},
+                { "email", email}
+            };
+
+            var headers = new Dictionary<string, object>
+            {
+                { "kid",  keyId}
+            };
+
+            if (roleIds != null && roleIds.Any())
+            {
+                payload.Add("roles", roleIds);
+            }
+            if (groupIds != null && groupIds.Any())
+            {
+                payload.Add("groups", groupIds);
+            }
+
+            using (var rsa = new RSACryptoServiceProvider(2048))
+            {
+                var rsaParametersPublic = rsa.ExportParameters(includePrivateParameters: false);
+                key = new RsaSecurityKey(rsaParametersPublic) {KeyId = keyId};
+
+                var algorithm = new RS256AlgorithmRsaOnly(rsa);
+                var serializer = new JsonNetSerializer();
+                var urlEncoder = new JwtBase64UrlEncoder();
+                var encoder = new JwtEncoder(algorithm, serializer, urlEncoder);
+                var token = encoder.Encode(headers, payload, string.Empty);
+
+                return token;
+            }
+        }
+
+        protected void AssertClaims(
+            ClaimsPrincipal principal,
+            string issuer = DefaultIssuer,
+            string clientid = DefaultClientId,
+            string nonce = Nonce,
+            string subject = DefaultSubject,
+            string name = DefaultName,
+            string email = DefaultEmail)
+        {
+            Assert.IsTrue(principal.HasClaim(x => x.Type == "iss" && x.Value == issuer));
+            Assert.IsTrue(principal.HasClaim(x => x.Type == "aud" && x.Value == clientid));
+            Assert.IsTrue(principal.HasClaim(x => x.Type == "nonce" && x.Value == nonce));
+            Assert.IsTrue(principal.HasClaim(x => x.Type == "name" && x.Value == name));
+            Assert.IsTrue(principal.HasClaim(x => x.Type == ClaimTypes.NameIdentifier && x.Value == subject));
+            Assert.IsTrue(principal.HasClaim(x => x.Type == ClaimTypes.Email && x.Value == email));
+        }
+    }
+}

--- a/source/OpenIDConnectAuthenticationProvider.sln.DotSettings
+++ b/source/OpenIDConnectAuthenticationProvider.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Implicit</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AD/@EntryIndexedValue">AD</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CSS/@EntryIndexedValue">CSS</s:String>
@@ -7,6 +8,11 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/source/Server.Extensibility.Authentication.AzureAD/Configuration/AzureADConfiguration.cs
+++ b/source/Server.Extensibility.Authentication.AzureAD/Configuration/AzureADConfiguration.cs
@@ -2,7 +2,7 @@
 
 namespace Octopus.Server.Extensibility.Authentication.AzureAD.Configuration
 {
-    public class AzureADConfiguration : OpenIDConnectConfiguration
+    public class AzureADConfiguration : OpenIDConnectConfigurationWithRole
     {
         public static string DefaultRoleClaimType = "roles";
 
@@ -11,7 +11,5 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD.Configuration
             Id = AzureADConfigurationStore.SingletonId;
             RoleClaimType = DefaultRoleClaimType;
         }
-
-        public string RoleClaimType { get; set; }
     }
 }

--- a/source/Server.Extensibility.Authentication.AzureAD/Configuration/AzureADConfigurationStore.cs
+++ b/source/Server.Extensibility.Authentication.AzureAD/Configuration/AzureADConfigurationStore.cs
@@ -4,7 +4,7 @@ using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration;
 
 namespace Octopus.Server.Extensibility.Authentication.AzureAD.Configuration
 {
-    public class AzureADConfigurationStore : OpenIdConnectConfigurationStore<AzureADConfiguration>, IAzureADConfigurationStore
+    public class AzureADConfigurationStore : OpenIdConnectConfigurationWithRoleStore<AzureADConfiguration>, IAzureADConfigurationStore
     {
         public const string SingletonId = "authentication-aad";
 
@@ -16,16 +16,6 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD.Configuration
             IConfigurationStore configurationStore,
             IResourceMappingFactory factory) : base(configurationStore, factory)
         {
-        }
-
-        public string GetRoleClaimType()
-        {
-            return GetProperty(doc => doc.RoleClaimType);
-        }
-
-        public void SetRoleClaimType(string roleClaimType)
-        {
-            SetProperty(doc => doc.RoleClaimType = roleClaimType);
         }
     }
 }

--- a/source/Server.Extensibility.Authentication.AzureAD/Configuration/IAzureADConfigurationStore.cs
+++ b/source/Server.Extensibility.Authentication.AzureAD/Configuration/IAzureADConfigurationStore.cs
@@ -2,9 +2,7 @@
 
 namespace Octopus.Server.Extensibility.Authentication.AzureAD.Configuration
 {
-    public interface IAzureADConfigurationStore : IOpenIDConnectConfigurationStore<AzureADConfiguration>
+    public interface IAzureADConfigurationStore : IOpenIDConnectConfigurationWithRoleStore<AzureADConfiguration>
     {
-        string GetRoleClaimType();
-        void SetRoleClaimType(string roleClaimType);
     }
 }

--- a/source/Server.Extensibility.Authentication.AzureAD/Tokens/AzureADAuthTokenHandler.cs
+++ b/source/Server.Extensibility.Authentication.AzureAD/Tokens/AzureADAuthTokenHandler.cs
@@ -1,23 +1,15 @@
 ﻿using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Configuration;
-using Microsoft.IdentityModel.Tokens;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
-using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Tokens;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
 
 namespace Octopus.Server.Extensibility.Authentication.AzureAD.Tokens
 {
-    public class AzureADAuthTokenHandler : OpenIDConnectAuthTokenHandler<IAzureADConfigurationStore, IKeyRetriever>, IAzureADAuthTokenHandler
+    public class AzureADAuthTokenHandler : OpenIDConnectAuthTokenWithRolesHandler<IAzureADConfigurationStore, IKeyRetriever>, IAzureADAuthTokenHandler
     {
         public AzureADAuthTokenHandler(ILog log, IAzureADConfigurationStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
         {
-        }
-
-        protected override void SetIssuerSpecificTokenValidationParameters(TokenValidationParameters validationParameters)
-        {
-            if (!string.IsNullOrWhiteSpace(ConfigurationStore.GetRoleClaimType()))
-                validationParameters.RoleClaimType = ConfigurationStore.GetRoleClaimType();
         }
     }
 }

--- a/source/Server.Extensibility.Authentication.Okta/Configuration/IOktaConfigurationStore.cs
+++ b/source/Server.Extensibility.Authentication.Okta/Configuration/IOktaConfigurationStore.cs
@@ -2,9 +2,7 @@
 
 namespace Octopus.Server.Extensibility.Authentication.Okta.Configuration
 {
-    public interface IOktaConfigurationStore : IOpenIDConnectConfigurationStore<OktaConfiguration>
+    public interface IOktaConfigurationStore : IOpenIDConnectConfigurationWithRoleStore<OktaConfiguration>
     {
-        string GetRoleClaimType();
-        void SetRoleClaimType(string roleClaimType);
     }
 }

--- a/source/Server.Extensibility.Authentication.Okta/Configuration/OktaConfiguration.cs
+++ b/source/Server.Extensibility.Authentication.Okta/Configuration/OktaConfiguration.cs
@@ -2,16 +2,15 @@
 
 namespace Octopus.Server.Extensibility.Authentication.Okta.Configuration
 {
-    public class OktaConfiguration : OpenIDConnectConfiguration
+    public class OktaConfiguration : OpenIDConnectConfigurationWithRole
     {
-        public static string DefaultRoleClaimType = "roles";
+        public static string DefaultRoleClaimType = "groups";
 
         public OktaConfiguration() : base("Okta", "Octopus Deploy", "1.0")
         {
             Id = OktaConfigurationStore.SingletonId;
             RoleClaimType = DefaultRoleClaimType;
+            Scope = DefaultScope + "%20groups";
         }
-
-        public string RoleClaimType { get; set; }
     }
 }

--- a/source/Server.Extensibility.Authentication.Okta/Configuration/OktaConfigurationStore.cs
+++ b/source/Server.Extensibility.Authentication.Okta/Configuration/OktaConfigurationStore.cs
@@ -4,7 +4,7 @@ using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration;
 
 namespace Octopus.Server.Extensibility.Authentication.Okta.Configuration
 {
-    public class OktaConfigurationStore : OpenIdConnectConfigurationStore<OktaConfiguration>, IOktaConfigurationStore
+    public class OktaConfigurationStore : OpenIdConnectConfigurationWithRoleStore<OktaConfiguration>, IOktaConfigurationStore
     {
         public const string SingletonId = "authentication-od";
 
@@ -16,16 +16,6 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Configuration
             IConfigurationStore configurationStore,
             IResourceMappingFactory factory) : base(configurationStore, factory)
         {
-        }
-
-        public string GetRoleClaimType()
-        {
-            return GetProperty(doc => doc.RoleClaimType);
-        }
-
-        public void SetRoleClaimType(string roleClaimType)
-        {
-            SetProperty(doc => doc.RoleClaimType = roleClaimType);
         }
     }
 }

--- a/source/Server.Extensibility.Authentication.Okta/OktaExtension.cs
+++ b/source/Server.Extensibility.Authentication.Okta/OktaExtension.cs
@@ -34,6 +34,7 @@ namespace Octopus.Server.Extensibility.Authentication.Okta
 
             builder.RegisterType<OktaConfigurationStore>()
                 .As<IOktaConfigurationStore>()
+                .As<IOktaConfigurationStore>()
                 .InstancePerDependency();
             builder.RegisterType<OktaConfigurationSettings>()
                 .As<IOktaConfigurationSettings>()

--- a/source/Server.Extensibility.Authentication.Okta/OktaExtension.cs
+++ b/source/Server.Extensibility.Authentication.Okta/OktaExtension.cs
@@ -34,7 +34,6 @@ namespace Octopus.Server.Extensibility.Authentication.Okta
 
             builder.RegisterType<OktaConfigurationStore>()
                 .As<IOktaConfigurationStore>()
-                .As<IOktaConfigurationStore>()
                 .InstancePerDependency();
             builder.RegisterType<OktaConfigurationSettings>()
                 .As<IOktaConfigurationSettings>()

--- a/source/Server.Extensibility.Authentication.Okta/Tokens/OktaAuthTokenHandler.cs
+++ b/source/Server.Extensibility.Authentication.Okta/Tokens/OktaAuthTokenHandler.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.IdentityModel.Tokens;
-using Octopus.Diagnostics;
+﻿using Octopus.Diagnostics;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
 using Octopus.Server.Extensibility.Authentication.Okta.Configuration;
@@ -7,16 +6,10 @@ using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
 
 namespace Octopus.Server.Extensibility.Authentication.Okta.Tokens
 {
-    public class OktaAuthTokenHandler : OpenIDConnectAuthTokenHandler<IOktaConfigurationStore, IKeyRetriever>, IOktaAuthTokenHandler
+    public class OktaAuthTokenHandler : OpenIDConnectAuthTokenWithRolesHandler<IOktaConfigurationStore, IKeyRetriever>, IOktaAuthTokenHandler
     {
         public OktaAuthTokenHandler(ILog log, IOktaConfigurationStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
         {
-        }
-
-        protected override void SetIssuerSpecificTokenValidationParameters(TokenValidationParameters validationParameters)
-        {
-            if (!string.IsNullOrWhiteSpace(ConfigurationStore.GetRoleClaimType()))
-                validationParameters.RoleClaimType = ConfigurationStore.GetRoleClaimType();
         }
     }
 }

--- a/source/Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationWithRoleStore.cs
+++ b/source/Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationWithRoleStore.cs
@@ -1,0 +1,25 @@
+﻿using Nevermore.Contracts;
+using Octopus.Data.Storage.Configuration;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Configuration;
+using Octopus.Node.Extensibility.HostServices.Mapping;
+
+namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration
+{
+    public abstract class OpenIdConnectConfigurationWithRoleStore<TConfiguration> : OpenIdConnectConfigurationStore<TConfiguration>, IOpenIDConnectConfigurationWithRoleStore<TConfiguration>
+        where TConfiguration : OpenIDConnectConfigurationWithRole, IId, new()
+    {
+        protected OpenIdConnectConfigurationWithRoleStore(IConfigurationStore configurationStore, IResourceMappingFactory factory) : base(configurationStore, factory)
+        {
+        }
+
+        public string GetRoleClaimType()
+        {
+            return GetProperty(doc => doc.RoleClaimType);
+        }
+
+        public void SetRoleClaimType(string roleClaimType)
+        {
+            SetProperty(doc => doc.RoleClaimType = roleClaimType);
+        }
+    }
+}

--- a/source/Server.Extensibility.Authentication.OpenIDConnect/Tokens/OpenIDConnectAuthTokenWithRolesHandler.cs
+++ b/source/Server.Extensibility.Authentication.OpenIDConnect/Tokens/OpenIDConnectAuthTokenWithRolesHandler.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+using System.Security.Claims;
+using Microsoft.IdentityModel.Tokens;
+using Octopus.Diagnostics;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Configuration;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
+
+namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens
+{
+    public abstract class OpenIDConnectAuthTokenWithRolesHandler<TStore, TRetriever> : OpenIDConnectAuthTokenHandler<TStore, TRetriever>
+        where TStore : IOpenIDConnectConfigurationWithRoleStore
+        where TRetriever : IKeyRetriever
+    {
+        protected OpenIDConnectAuthTokenWithRolesHandler(ILog log, TStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, TRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
+        {
+        }
+
+        protected override void SetIssuerSpecificTokenValidationParameters(TokenValidationParameters validationParameters)
+        {
+            if (!string.IsNullOrWhiteSpace(ConfigurationStore.GetRoleClaimType()))
+                validationParameters.RoleClaimType = ConfigurationStore.GetRoleClaimType();
+        }
+
+        protected override string[] GetProviderRoleIds(ClaimsPrincipal principal)
+        {
+            var roleClaimType = ConfigurationStore.GetRoleClaimType();
+
+            if (string.IsNullOrWhiteSpace(roleClaimType))
+                return new string[0];
+
+            var groups = principal.FindAll(ClaimTypes.Role)
+                .Union(principal.FindAll(roleClaimType))
+                .Select(c => c.Value).ToArray();
+
+            return groups;
+        }
+    }
+}

--- a/source/Server.Extensibility.Authentication.OpenIDConnect/Web/UserAuthenticatedAction.cs
+++ b/source/Server.Extensibility.Authentication.OpenIDConnect/Web/UserAuthenticatedAction.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
-using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Nancy;
@@ -74,10 +73,10 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
             // Step 1: Try and get all of the details from the request making sure there are no errors passed back from the external identity provider
             string stateFromRequest;
             var principalContainer = await authTokenHandler.GetPrincipalAsync(((DynamicDictionary)context.Request.Form).ToDictionary(), out stateFromRequest);
-            var principal = principalContainer.principal;
-            if (principal == null || !string.IsNullOrEmpty(principalContainer.error))
+            var principal = principalContainer.Principal;
+            if (principal == null || !string.IsNullOrEmpty(principalContainer.Error))
             {
-                return BadRequest($"The response from the external identity provider contained an error: {principalContainer.error}");
+                return BadRequest($"The response from the external identity provider contained an error: {principalContainer.Error}");
             }
             
             // Step 2: Validate the state object we passed wasn't tampered with
@@ -133,7 +132,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
             {
                 // Step 4b: Try to get or create a the Octopus User this external identity represents
-                var userResult = GetOrCreateUser(authenticationCandidate, principal, cts.Token);
+                var userResult = GetOrCreateUser(authenticationCandidate, principalContainer.ExternalRoleIds, cts.Token);
                 if (userResult.Succeeded)
                 {
                     loginTracker.RecordSucess(authenticationCandidate.Username, context.Request.UserHostAddress);
@@ -186,10 +185,8 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Web
                 .WithCookie(new NancyCookie("n", Guid.NewGuid().ToString(), true, false, DateTime.MinValue));
         }
 
-        UserCreateResult GetOrCreateUser(UserResource userResource, ClaimsPrincipal principal, CancellationToken cancellationToken)
+        UserCreateResult GetOrCreateUser(UserResource userResource, string[] groups, CancellationToken cancellationToken)
         {
-            var groups = principal.FindAll(ClaimTypes.Role).Select(c => c.Value).ToArray();
-
             var identityToMatch = NewIdentity(userResource);
 
             var user = userStore.GetByIdentity(identityToMatch);

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Cake" version="0.16.0" />
+	<package id="Cake" version="0.26.1" />
 </packages>


### PR DESCRIPTION
We'd been holding the RoleClaimType a bit wrong. The crux of this fix is the following

```
var groups = principal.FindAll(ClaimTypes.Role)
                 .Concat(principal.FindAll(roleClaimType))
                 .Select(c => c.Value).ToArray();
```

in `OpenIDConnectAuthTokenWithRolesHandler`. The rest of this PR is refactoring so AzureAD and Okta are sharing this now instead of having their own copies of it. The refactor is also so that the groups are passed back out of `GetPrincipalAsync` in the `PrincipalContainer`.

Have retested against AzureAD and Okta.