### PR TITLE
Update resource mapping server extensibility

### DIFF
--- a/source/Node.Extensibility.Authentication.OpenIDConnect/Node.Extensibility.Authentication.OpenIDConnect.csproj
+++ b/source/Node.Extensibility.Authentication.OpenIDConnect/Node.Extensibility.Authentication.OpenIDConnect.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.0.12" />
-    <PackageReference Include="Octopus.Node.Extensibility" Version="4.0.0" />
+    <PackageReference Include="Octopus.Node.Extensibility" Version="4.0.2-resourcemappingr0003" />
     <PackageReference Include="Octopus.Node.Extensibility.Authentication" Version="7.0.0" />
     <PackageReference Include="Octopus.Time" Version="1.1.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.0" />

--- a/source/Node.Extensibility.Authentication.OpenIDConnect/Node.Extensibility.Authentication.OpenIDConnect.csproj
+++ b/source/Node.Extensibility.Authentication.OpenIDConnect/Node.Extensibility.Authentication.OpenIDConnect.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.0.12" />
-    <PackageReference Include="Octopus.Node.Extensibility" Version="4.0.2-resourcemappingr0003" />
+    <PackageReference Include="Octopus.Node.Extensibility" Version="5.0.0" />
     <PackageReference Include="Octopus.Node.Extensibility.Authentication" Version="7.0.0" />
     <PackageReference Include="Octopus.Time" Version="1.1.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.0" />

--- a/source/Node.Extensibility.Authentication.Tests/Node.Extensibility.Authentication.Tests.csproj
+++ b/source/Node.Extensibility.Authentication.Tests/Node.Extensibility.Authentication.Tests.csproj
@@ -69,14 +69,14 @@
     <Reference Include="Octopus.Diagnostics, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.12\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
     </Reference>
-    <Reference Include="Octopus.Node.Extensibility, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Node.Extensibility.4.0.0\lib\netstandard1.2\Octopus.Node.Extensibility.dll</HintPath>
+    <Reference Include="Octopus.Node.Extensibility, Version=4.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Node.Extensibility.4.0.2-resourcemappingr0003\lib\netstandard1.2\Octopus.Node.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Node.Extensibility.Authentication, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\Octopus.Node.Extensibility.Authentication.7.0.0\lib\netstandard1.2\Octopus.Node.Extensibility.Authentication.dll</HintPath>
     </Reference>
-    <Reference Include="Octopus.Server.Extensibility, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.4.0.0\lib\net451\Octopus.Server.Extensibility.dll</HintPath>
+    <Reference Include="Octopus.Server.Extensibility, Version=4.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Server.Extensibility.4.0.2-resourcemappingr0003\lib\net451\Octopus.Server.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/source/Node.Extensibility.Authentication.Tests/Node.Extensibility.Authentication.Tests.csproj
+++ b/source/Node.Extensibility.Authentication.Tests/Node.Extensibility.Authentication.Tests.csproj
@@ -69,14 +69,14 @@
     <Reference Include="Octopus.Diagnostics, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.12\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
     </Reference>
-    <Reference Include="Octopus.Node.Extensibility, Version=4.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Node.Extensibility.4.0.2-resourcemappingr0003\lib\netstandard1.2\Octopus.Node.Extensibility.dll</HintPath>
+    <Reference Include="Octopus.Node.Extensibility, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Node.Extensibility.5.0.0\lib\netstandard1.2\Octopus.Node.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Node.Extensibility.Authentication, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\Octopus.Node.Extensibility.Authentication.7.0.0\lib\netstandard1.2\Octopus.Node.Extensibility.Authentication.dll</HintPath>
     </Reference>
-    <Reference Include="Octopus.Server.Extensibility, Version=4.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Server.Extensibility.4.0.2-resourcemappingr0003\lib\net451\Octopus.Server.Extensibility.dll</HintPath>
+    <Reference Include="Octopus.Server.Extensibility, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Server.Extensibility.5.0.0\lib\net451\Octopus.Server.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -118,7 +118,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Node.Extensibility.Authentication.OpenIDConnect\Node.Extensibility.Authentication.OpenIDConnect.csproj">
@@ -134,6 +136,8 @@
       <Name>Server.Extensibility.Authentication.OpenIDConnect</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/source/Node.Extensibility.Authentication.Tests/packages.config
+++ b/source/Node.Extensibility.Authentication.Tests/packages.config
@@ -15,9 +15,9 @@
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
   <package id="Octopus.Data" version="4.0.0" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.12" targetFramework="net451" />
-  <package id="Octopus.Node.Extensibility" version="4.0.0" targetFramework="net451" />
+  <package id="Octopus.Node.Extensibility" version="4.0.2-resourcemappingr0003" targetFramework="net451" />
   <package id="Octopus.Node.Extensibility.Authentication" version="7.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility" version="4.0.0" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility" version="4.0.2-resourcemappingr0003" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
   <package id="System.ComponentModel.Annotations" version="4.3.0" targetFramework="net451" />

--- a/source/Node.Extensibility.Authentication.Tests/packages.config
+++ b/source/Node.Extensibility.Authentication.Tests/packages.config
@@ -15,9 +15,9 @@
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
   <package id="Octopus.Data" version="4.0.0" targetFramework="net451" />
   <package id="Octopus.Diagnostics" version="1.0.12" targetFramework="net451" />
-  <package id="Octopus.Node.Extensibility" version="4.0.2-resourcemappingr0003" targetFramework="net451" />
+  <package id="Octopus.Node.Extensibility" version="5.0.0" targetFramework="net451" />
   <package id="Octopus.Node.Extensibility.Authentication" version="7.0.0" targetFramework="net451" />
-  <package id="Octopus.Server.Extensibility" version="4.0.2-resourcemappingr0003" targetFramework="net451" />
+  <package id="Octopus.Server.Extensibility" version="5.0.0" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
   <package id="System.ComponentModel.Annotations" version="4.3.0" targetFramework="net451" />

--- a/source/Server.Extensibility.Authentication.AzureAD/Configuration/AzureADConfigurationSettings.cs
+++ b/source/Server.Extensibility.Authentication.AzureAD/Configuration/AzureADConfigurationSettings.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
 using Octopus.Node.Extensibility.Extensions.Infrastructure.Configuration;
-using Octopus.Node.Extensibility.HostServices.Mapping;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration;
 
 namespace Octopus.Server.Extensibility.Authentication.AzureAD.Configuration
 {
     public class AzureADConfigurationSettings : OpenIdConnectConfigurationSettings<AzureADConfiguration, AzureADConfigurationResource, IAzureADConfigurationStore>, IAzureADConfigurationSettings
     {
-        public AzureADConfigurationSettings(IAzureADConfigurationStore configurationDocumentStore, IResourceMappingFactory factory) : base(configurationDocumentStore, factory)
+        public AzureADConfigurationSettings(IAzureADConfigurationStore configurationDocumentStore) : base(configurationDocumentStore)
         {
         }
 

--- a/source/Server.Extensibility.Authentication.AzureAD/Configuration/AzureADConfigurationStore.cs
+++ b/source/Server.Extensibility.Authentication.AzureAD/Configuration/AzureADConfigurationStore.cs
@@ -1,5 +1,4 @@
 ﻿using Octopus.Data.Storage.Configuration;
-using Octopus.Node.Extensibility.HostServices.Mapping;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration;
 
 namespace Octopus.Server.Extensibility.Authentication.AzureAD.Configuration
@@ -13,8 +12,7 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD.Configuration
         public override string ConfigurationSettingsName => "AzureAD";
 
         public AzureADConfigurationStore(
-            IConfigurationStore configurationStore,
-            IResourceMappingFactory factory) : base(configurationStore, factory)
+            IConfigurationStore configurationStore) : base(configurationStore)
         {
         }
     }

--- a/source/Server.Extensibility.Authentication.GoogleApps/Configuration/GoogleAppsConfigurationSettings.cs
+++ b/source/Server.Extensibility.Authentication.GoogleApps/Configuration/GoogleAppsConfigurationSettings.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
 using Octopus.Node.Extensibility.Extensions.Infrastructure.Configuration;
-using Octopus.Node.Extensibility.HostServices.Mapping;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration;
 
 namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration
 {
     public class GoogleAppsConfigurationSettings : OpenIdConnectConfigurationSettings<GoogleAppsConfiguration, GoogleAppsConfigurationResource, IGoogleAppsConfigurationStore>, IGoogleAppsConfigurationSettings
     {
-        public GoogleAppsConfigurationSettings(IGoogleAppsConfigurationStore configurationDocumentStore, IResourceMappingFactory factory) : base(configurationDocumentStore, factory)
+        public GoogleAppsConfigurationSettings(IGoogleAppsConfigurationStore configurationDocumentStore) : base(configurationDocumentStore)
         {
         }
 

--- a/source/Server.Extensibility.Authentication.GoogleApps/Configuration/GoogleAppsConfigurationStore.cs
+++ b/source/Server.Extensibility.Authentication.GoogleApps/Configuration/GoogleAppsConfigurationStore.cs
@@ -1,5 +1,4 @@
 ﻿using Octopus.Data.Storage.Configuration;
-using Octopus.Node.Extensibility.HostServices.Mapping;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration;
 
 namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration
@@ -12,8 +11,7 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration
         public override string ConfigurationSettingsName => "GoogleApps";
 
         public GoogleAppsConfigurationStore(
-            IConfigurationStore configurationStore,
-            IResourceMappingFactory factory) : base(configurationStore, factory)
+            IConfigurationStore configurationStore) : base(configurationStore)
         {
         }
 

--- a/source/Server.Extensibility.Authentication.Okta/Configuration/OktaConfigurationSettings.cs
+++ b/source/Server.Extensibility.Authentication.Okta/Configuration/OktaConfigurationSettings.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
 using Octopus.Node.Extensibility.Extensions.Infrastructure.Configuration;
-using Octopus.Node.Extensibility.HostServices.Mapping;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration;
 
 namespace Octopus.Server.Extensibility.Authentication.Okta.Configuration
 {
     public class OktaConfigurationSettings : OpenIdConnectConfigurationSettings<OktaConfiguration, OktaConfigurationResource, IOktaConfigurationStore>, IOktaConfigurationSettings
     {
-        public OktaConfigurationSettings(IOktaConfigurationStore configurationDocumentStore, IResourceMappingFactory factory) : base(configurationDocumentStore, factory)
+        public OktaConfigurationSettings(IOktaConfigurationStore configurationDocumentStore) : base(configurationDocumentStore)
         {
         }
 

--- a/source/Server.Extensibility.Authentication.Okta/Configuration/OktaConfigurationStore.cs
+++ b/source/Server.Extensibility.Authentication.Okta/Configuration/OktaConfigurationStore.cs
@@ -1,5 +1,4 @@
 ﻿using Octopus.Data.Storage.Configuration;
-using Octopus.Node.Extensibility.HostServices.Mapping;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration;
 
 namespace Octopus.Server.Extensibility.Authentication.Okta.Configuration
@@ -13,8 +12,7 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Configuration
         public override string ConfigurationSettingsName => "Okta";
 
         public OktaConfigurationStore(
-            IConfigurationStore configurationStore,
-            IResourceMappingFactory factory) : base(configurationStore, factory)
+            IConfigurationStore configurationStore) : base(configurationStore)
         {
         }
     }

--- a/source/Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationStore.cs
+++ b/source/Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationStore.cs
@@ -3,7 +3,6 @@ using Nevermore.Contracts;
 using Octopus.Data.Storage.Configuration;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Configuration;
 using Octopus.Node.Extensibility.Extensions.Infrastructure.Configuration;
-using Octopus.Node.Extensibility.HostServices.Mapping;
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration
 {
@@ -13,8 +12,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuratio
         public abstract string ConfigurationSettingsName { get; }
 
         protected OpenIdConnectConfigurationStore(
-            IConfigurationStore configurationStore, 
-            IResourceMappingFactory factory) : base(configurationStore, factory)
+            IConfigurationStore configurationStore) : base(configurationStore)
         {
         }
 

--- a/source/Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationWithRoleStore.cs
+++ b/source/Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationWithRoleStore.cs
@@ -1,14 +1,13 @@
 ﻿using Nevermore.Contracts;
 using Octopus.Data.Storage.Configuration;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Configuration;
-using Octopus.Node.Extensibility.HostServices.Mapping;
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuration
 {
     public abstract class OpenIdConnectConfigurationWithRoleStore<TConfiguration> : OpenIdConnectConfigurationStore<TConfiguration>, IOpenIDConnectConfigurationWithRoleStore<TConfiguration>
         where TConfiguration : OpenIDConnectConfigurationWithRole, IId, new()
     {
-        protected OpenIdConnectConfigurationWithRoleStore(IConfigurationStore configurationStore, IResourceMappingFactory factory) : base(configurationStore, factory)
+        protected OpenIdConnectConfigurationWithRoleStore(IConfigurationStore configurationStore) : base(configurationStore)
         {
         }
 

--- a/source/Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIdConnectConfigurationSettings.cs
+++ b/source/Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIdConnectConfigurationSettings.cs
@@ -10,7 +10,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuratio
         where TResource : ExtensionConfigurationResource
         where TDocumentStore : IOpenIDConnectConfigurationStore<TConfiguration>
     {
-        protected OpenIdConnectConfigurationSettings(TDocumentStore configurationDocumentStore, IResourceMappingFactory factory) : base(configurationDocumentStore, factory)
+        protected OpenIdConnectConfigurationSettings(TDocumentStore configurationDocumentStore) : base(configurationDocumentStore)
         {
         }
 
@@ -30,9 +30,9 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuratio
             yield return new ConfigurationValue($"Octopus.{configurationSettingsName}.AllowAutoUserCreation", ConfigurationDocumentStore.GetAllowAutoUserCreation().ToString(), isEnabled, "Allow auto user creation");
         }
 
-        public override IEnumerable<IResourceMapping> GetMappings()
+        public override void BuildMappings(IResourceMappingsBuilder builder)
         {
-            return new[] { ResourceMappingFactory.Create<TResource, TConfiguration>() };
+            builder.Map<TResource, TConfiguration>();
         }
     }
 }

--- a/source/Server.Extensibility.Authentication.OpenIDConnect/Server.Extensibility.Authentication.OpenIdConnect.csproj
+++ b/source/Server.Extensibility.Authentication.OpenIDConnect/Server.Extensibility.Authentication.OpenIdConnect.csproj
@@ -11,9 +11,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="Nancy" Version="1.2.0" />
     <PackageReference Include="Nancy.Serialization.JsonNet" Version="1.2.0" />
-    <PackageReference Include="Octopus.Node.Extensibility" Version="4.0.2-resourcemappingr0003" />
+    <PackageReference Include="Octopus.Node.Extensibility" Version="5.0.0" />
     <PackageReference Include="Octopus.Node.Extensibility.Authentication" Version="7.0.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="4.0.2-resourcemappingr0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="5.0.0" />
     <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="7.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.0" />

--- a/source/Server.Extensibility.Authentication.OpenIDConnect/Server.Extensibility.Authentication.OpenIdConnect.csproj
+++ b/source/Server.Extensibility.Authentication.OpenIDConnect/Server.Extensibility.Authentication.OpenIdConnect.csproj
@@ -11,9 +11,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="Nancy" Version="1.2.0" />
     <PackageReference Include="Nancy.Serialization.JsonNet" Version="1.2.0" />
-    <PackageReference Include="Octopus.Node.Extensibility" Version="4.0.0" />
+    <PackageReference Include="Octopus.Node.Extensibility" Version="4.0.2-resourcemappingr0003" />
     <PackageReference Include="Octopus.Node.Extensibility.Authentication" Version="7.0.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="4.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="4.0.2-resourcemappingr0003" />
     <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="7.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.0" />


### PR DESCRIPTION
The resource mapping part of `Octopus.Server.Extensibility` has changed. I'm updating this solution accordingly.