### PR TITLE
AllowAutoUserCreation should not be nullable, we'll add a migration t…

### DIFF
--- a/source/Node.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfiguration.cs
+++ b/source/Node.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfiguration.cs
@@ -12,6 +12,7 @@ namespace Octopus.Node.Extensibility.Authentication.OpenIDConnect.Configuration
 
         protected OpenIDConnectConfiguration()
         {
+            AllowAutoUserCreation = true;
         }
 
         protected OpenIDConnectConfiguration(string name, string author, string configurationSchemaVersion) : base(name, author, configurationSchemaVersion)
@@ -19,6 +20,8 @@ namespace Octopus.Node.Extensibility.Authentication.OpenIDConnect.Configuration
             Scope = DefaultScope;
 
             NameClaimType = DefaultNameClaimType;
+
+            AllowAutoUserCreation = true;
         }
 
         public string Issuer { get; set; }
@@ -29,7 +32,7 @@ namespace Octopus.Node.Extensibility.Authentication.OpenIDConnect.Configuration
 
         public string NameClaimType { get; set; }
 
-        public bool? AllowAutoUserCreation { get; set; }
+        public bool AllowAutoUserCreation { get; set; }
 
         public void SetId(string id)
         {

--- a/source/Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationStore.cs
+++ b/source/Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigurationStore.cs
@@ -63,7 +63,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuratio
 
         public bool GetAllowAutoUserCreation()
         {
-            return GetProperty(doc => doc.AllowAutoUserCreation.GetValueOrDefault(true));
+            return GetProperty(doc => doc.AllowAutoUserCreation);
         }
 
         public void SetAllowAutoUserCreation(bool allowAutoUserCreation)


### PR DESCRIPTION
…o make existing records without a value explicitly set to true

Relates to OctopusDeploy/Issues/issues/4770