### PR TITLE
Change the default enabled state for OctopusID

### DIFF
--- a/source/Server.Extensibility.Authentication.OctopusID/Configuration/OctopusIDConfiguration.cs
+++ b/source/Server.Extensibility.Authentication.OctopusID/Configuration/OctopusIDConfiguration.cs
@@ -6,13 +6,12 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
     {
         public static string DefaultRoleClaimType = "roles";
 
-        public OctopusIDConfiguration() : base("OctopusID", "Octopus Deploy", "1.0")
+        public OctopusIDConfiguration() : base("OctopusID", "Octopus Deploy", "1.1")
         {
             Id = OctopusIDConfigurationStore.SingletonId;
             Issuer = "https://account.octopus.com";
             Scope = DefaultScope;
             RoleClaimType = DefaultRoleClaimType;
-            IsEnabled = true;
         }
         
         public string RoleClaimType { get; set; }

--- a/source/Server.Extensibility.Authentication.OctopusID/Configuration/OctopusIDDatabaseInitializer.cs
+++ b/source/Server.Extensibility.Authentication.OctopusID/Configuration/OctopusIDDatabaseInitializer.cs
@@ -5,10 +5,32 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
 {
     public class OctopusIDDatabaseInitializer : DatabaseInitializer<OctopusIDConfiguration>
     {
+        readonly IConfigurationStore configurationStore;
+
         public OctopusIDDatabaseInitializer(IConfigurationStore configurationStore) : base(configurationStore)
         {
+            this.configurationStore = configurationStore;
         }
 
         protected override string SingletonId => OctopusIDConfigurationStore.SingletonId;
+
+        public override void Execute()
+        {
+            base.Execute();
+            
+            var doc = configurationStore.Get<OctopusIDConfiguration>(SingletonId);
+
+            if (doc.ConfigurationSchemaVersion == "1.0")
+            {
+                // the plugin was initially intended for hosted only, and was going to be always enabled. When
+                // the distribution changed to include in all instances the default wasn't changed back to false.
+                // This is a once off change to disable the provider in any existing instances that haven't been
+                // configured by the cloud infrastructure to have to use Octopus ID
+                doc.IsEnabled = !string.IsNullOrWhiteSpace(doc.ClientId);
+                doc.ConfigurationSchemaVersion = "1.1";
+                
+                configurationStore.Update(doc);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes an issue where Octopus ID is always enabled, and started emitting Warning messages about incomplete config into the server logs.