### PR TITLE
feat(OctopusID): Support localhost issuers for Octopus ID

### DIFF
--- a/source/Node.Extensibility.Authentication.OpenIDConnect/OpenIDConnectExtension.cs
+++ b/source/Node.Extensibility.Authentication.OpenIDConnect/OpenIDConnectExtension.cs
@@ -9,7 +9,6 @@ namespace Octopus.Node.Extensibility.Authentication.OpenIDConnect
         public virtual void Load(ContainerBuilder builder)
         {
             builder.RegisterType<PrincipalToUserResourceMapper>().As<IPrincipalToUserResourceMapper>().InstancePerDependency();
-            builder.RegisterType<IdentityProviderConfigDiscoverer>().As<IIdentityProviderConfigDiscoverer>().SingleInstance();
         }
     }
 }

--- a/source/Node.Extensibility.Authentication.OpenIDConnect/Tokens/AuthTokenHandler.cs
+++ b/source/Node.Extensibility.Authentication.OpenIDConnect/Tokens/AuthTokenHandler.cs
@@ -13,19 +13,20 @@ using Octopus.Diagnostics;
 
 namespace Octopus.Node.Extensibility.Authentication.OpenIDConnect.Tokens
 {
-    public abstract class AuthTokenHandler<TStore, TRetriever>
+    public abstract class AuthTokenHandler<TStore, TRetriever, TDiscoverer>
         where TStore : IOpenIDConnectConfigurationStore
         where TRetriever : IKeyRetriever
+        where TDiscoverer : IIdentityProviderConfigDiscoverer
     {
         static string[] hmacAlgorithms = {SecurityAlgorithms.HmacSha256, SecurityAlgorithms.HmacSha384, SecurityAlgorithms.HmacSha512};
         
-        readonly IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer;
+        readonly TDiscoverer identityProviderConfigDiscoverer;
         readonly TRetriever keyRetriever;
         protected readonly ILog Log;
         protected readonly TStore ConfigurationStore;
 
         protected AuthTokenHandler(TStore configurationStore,
-            IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer,
+            TDiscoverer identityProviderConfigDiscoverer,
             TRetriever keyRetriever,
             ILog log)
         {

--- a/source/Node.Extensibility.Authentication.Tests/Node.Extensibility.Authentication.Tests.csproj
+++ b/source/Node.Extensibility.Authentication.Tests/Node.Extensibility.Authentication.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Assent" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Server.Extensibility.Authentication.OctopusID\Server.Extensibility.Authentication.OctopusID.csproj" />
     <ProjectReference Include="..\Server.Extensibility.Authentication.OpenIDConnect\Server.Extensibility.Authentication.OpenIDConnect.csproj" />
   </ItemGroup>
 </Project>

--- a/source/Node.Extensibility.Authentication.Tests/OctopusID/OctopusIdConfigDiscovererFixture.cs
+++ b/source/Node.Extensibility.Authentication.Tests/OctopusID/OctopusIdConfigDiscovererFixture.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Octopus.Server.Extensibility.Authentication.OctopusID;
+
+namespace Node.Extensibility.Authentication.Tests.OctopusID
+{
+    [TestFixture]
+    public class OctopusIdConfigDiscovererFixture
+    {
+        [Test]
+        [TestCase("https://someissuer/", "https://someissuer/", "https://someissuer/oauth2/authorize")]
+        [TestCase("https://someissuer", "https://someissuer/", "https://someissuer/oauth2/authorize")]
+        public async Task ShouldHandleTrailingSlashes(string inputIssuer, string expectedOutputIssuer, string expectedAuthorizationEndpoint)
+        {
+            var sut = new OctopusIdConfigDiscoverer();
+
+            var result = await sut.GetConfigurationAsync(inputIssuer);
+
+            Assert.AreEqual(expectedOutputIssuer, result.Issuer);
+            Assert.AreEqual(expectedAuthorizationEndpoint, result.AuthorizationEndpoint);
+        }
+    }
+}

--- a/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/CustomOpenIDConnectAuthTokenHandler.cs
+++ b/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/CustomOpenIDConnectAuthTokenHandler.cs
@@ -6,7 +6,7 @@ using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
 
 namespace Node.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
 {
-    public class CustomOpenIDConnectAuthTokenHandler : OpenIDConnectAuthTokenHandler<IOpenIDConnectConfigurationStore, IKeyRetriever>
+    public class CustomOpenIDConnectAuthTokenHandler : OpenIDConnectAuthTokenHandler<IOpenIDConnectConfigurationStore, IKeyRetriever, IIdentityProviderConfigDiscoverer>
     { 
         public CustomOpenIDConnectAuthTokenHandler(ILog log, IOpenIDConnectConfigurationStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
         {

--- a/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/CustomOpenIDConnectWithRoleAuthTokenHandler.cs
+++ b/source/Node.Extensibility.Authentication.Tests/OpenIdConnect/Tokens/CustomOpenIDConnectWithRoleAuthTokenHandler.cs
@@ -6,7 +6,7 @@ using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
 
 namespace Node.Extensibility.Authentication.Tests.OpenIdConnect.Tokens
 {
-    public class CustomOpenIDConnectWithRoleAuthTokenHandler : OpenIDConnectAuthTokenWithRolesHandler<IOpenIDConnectConfigurationWithRoleStore, IKeyRetriever>
+    public class CustomOpenIDConnectWithRoleAuthTokenHandler : OpenIDConnectAuthTokenWithRolesHandler<IOpenIDConnectConfigurationWithRoleStore, IKeyRetriever, IIdentityProviderConfigDiscoverer>
     { 
         public CustomOpenIDConnectWithRoleAuthTokenHandler(ILog log, IOpenIDConnectConfigurationWithRoleStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
         {

--- a/source/Server.Extensibility.Authentication.AzureAD/AzureADExtension.cs
+++ b/source/Server.Extensibility.Authentication.AzureAD/AzureADExtension.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Configuration;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Identities;
 using Octopus.Server.Extensibility.Authentication.AzureAD.Infrastructure;
@@ -24,6 +25,8 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD
         public override void Load(ContainerBuilder builder)
         {
             base.Load(builder);
+
+            builder.RegisterType<IdentityProviderConfigDiscoverer>().As<IIdentityProviderConfigDiscoverer>().SingleInstance();
 
             builder.RegisterType<AzureADDatabaseInitializer>().As<IExecuteWhenDatabaseInitializes>().InstancePerDependency();
             builder.RegisterType<AzureADPrincipalToUserResourceMapper>().As<IAzureADPrincipalToUserResourceMapper>().InstancePerDependency();

--- a/source/Server.Extensibility.Authentication.AzureAD/Tokens/AzureADAuthTokenHandler.cs
+++ b/source/Server.Extensibility.Authentication.AzureAD/Tokens/AzureADAuthTokenHandler.cs
@@ -6,7 +6,7 @@ using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
 
 namespace Octopus.Server.Extensibility.Authentication.AzureAD.Tokens
 {
-    public class AzureADAuthTokenHandler : OpenIDConnectAuthTokenWithRolesHandler<IAzureADConfigurationStore, IAzureADKeyRetriever>, IAzureADAuthTokenHandler
+    public class AzureADAuthTokenHandler : OpenIDConnectAuthTokenWithRolesHandler<IAzureADConfigurationStore, IAzureADKeyRetriever, IIdentityProviderConfigDiscoverer>, IAzureADAuthTokenHandler
     {
         public AzureADAuthTokenHandler(ILog log, IAzureADConfigurationStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IAzureADKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
         {

--- a/source/Server.Extensibility.Authentication.GoogleApps/GoogleAppsExtension.cs
+++ b/source/Server.Extensibility.Authentication.GoogleApps/GoogleAppsExtension.cs
@@ -3,6 +3,7 @@ using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.Extensions.Identities;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
 using Octopus.Server.Extensibility.Extensions;
 using Octopus.Server.Extensibility.Extensions.Infrastructure;
 using Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration;
@@ -23,6 +24,8 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps
         public override void Load(ContainerBuilder builder)
         {
             base.Load(builder);
+
+            builder.RegisterType<IdentityProviderConfigDiscoverer>().As<IIdentityProviderConfigDiscoverer>().SingleInstance();
 
             builder.RegisterType<GoogleAppsDatabaseInitializer>().As<IExecuteWhenDatabaseInitializes>().InstancePerDependency();
             builder.RegisterType<GoogleAppsConfigurationMapping>().As<IConfigurationDocumentMapper>().InstancePerDependency();

--- a/source/Server.Extensibility.Authentication.GoogleApps/Tokens/GoogleAuthTokenHandler.cs
+++ b/source/Server.Extensibility.Authentication.GoogleApps/Tokens/GoogleAuthTokenHandler.cs
@@ -8,7 +8,7 @@ using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
 
 namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Tokens
 {
-    public class GoogleAuthTokenHandler : OpenIDConnectAuthTokenHandler<IGoogleAppsConfigurationStore, IGoogleKeyRetriever>, IGoogleAuthTokenHandler
+    public class GoogleAuthTokenHandler : OpenIDConnectAuthTokenHandler<IGoogleAppsConfigurationStore, IGoogleKeyRetriever, IIdentityProviderConfigDiscoverer>, IGoogleAuthTokenHandler
     {
         public GoogleAuthTokenHandler(ILog log, IGoogleAppsConfigurationStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IGoogleKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
         {

--- a/source/Server.Extensibility.Authentication.OctopusID/IOctopusIdentityProviderConfigDiscoverer.cs
+++ b/source/Server.Extensibility.Authentication.OctopusID/IOctopusIdentityProviderConfigDiscoverer.cs
@@ -1,0 +1,8 @@
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
+
+namespace Octopus.Server.Extensibility.Authentication.OctopusID
+{
+    public interface IOctopusIdentityProviderConfigDiscoverer : IIdentityProviderConfigDiscoverer
+    {
+    }
+}

--- a/source/Server.Extensibility.Authentication.OctopusID/OctopusIDExtension.cs
+++ b/source/Server.Extensibility.Authentication.OctopusID/OctopusIDExtension.cs
@@ -1,7 +1,6 @@
 ﻿using Autofac;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
-using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.Extensions.Identities;
 using Octopus.Server.Extensibility.Authentication.OctopusID.Configuration;
@@ -26,7 +25,7 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID
         {
             base.Load(builder);
 
-            builder.RegisterType<OctopusIdConfigDiscoverer>().As<IIdentityProviderConfigDiscoverer>().SingleInstance();
+            builder.RegisterType<OctopusIdConfigDiscoverer>().As<IOctopusIdentityProviderConfigDiscoverer>().InstancePerDependency();
 
             builder.RegisterType<OctopusIDDatabaseInitializer>().As<IExecuteWhenDatabaseInitializes>().InstancePerDependency();
             builder.RegisterType<OctopusIDPrincipalToUserResourceMapper>().As<IOctopusIDPrincipalToUserResourceMapper>().InstancePerDependency();

--- a/source/Server.Extensibility.Authentication.OctopusID/OctopusIDExtension.cs
+++ b/source/Server.Extensibility.Authentication.OctopusID/OctopusIDExtension.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.Extensions.Identities;
 using Octopus.Server.Extensibility.Authentication.OctopusID.Configuration;
@@ -24,6 +25,8 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID
         public override void Load(ContainerBuilder builder)
         {
             base.Load(builder);
+
+            builder.RegisterType<OctopusIdConfigDiscoverer>().As<IIdentityProviderConfigDiscoverer>().SingleInstance();
 
             builder.RegisterType<OctopusIDDatabaseInitializer>().As<IExecuteWhenDatabaseInitializes>().InstancePerDependency();
             builder.RegisterType<OctopusIDPrincipalToUserResourceMapper>().As<IOctopusIDPrincipalToUserResourceMapper>().InstancePerDependency();

--- a/source/Server.Extensibility.Authentication.OctopusID/OctopusIdConfigDiscoverer.cs
+++ b/source/Server.Extensibility.Authentication.OctopusID/OctopusIdConfigDiscoverer.cs
@@ -3,7 +3,7 @@ using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
 
 namespace Octopus.Server.Extensibility.Authentication.OctopusID
 {
-    public class OctopusIdConfigDiscoverer : IIdentityProviderConfigDiscoverer
+    public class OctopusIdConfigDiscoverer : IOctopusIdentityProviderConfigDiscoverer
     {
         public Task<IssuerConfiguration> GetConfigurationAsync(string issuer)
         {

--- a/source/Server.Extensibility.Authentication.OctopusID/OctopusIdConfigDiscoverer.cs
+++ b/source/Server.Extensibility.Authentication.OctopusID/OctopusIdConfigDiscoverer.cs
@@ -7,10 +7,10 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID
     {
         public Task<IssuerConfiguration> GetConfigurationAsync(string issuer)
         {
-            return Task.FromResult(new IssuerConfiguration()
+            return Task.FromResult(new IssuerConfiguration
             {
-                Issuer = issuer + "/", // NOTE: the trailing / is important!
-                AuthorizationEndpoint = issuer + "/oauth2/authorize"
+                Issuer = issuer.WithTrailingSlash(),
+                AuthorizationEndpoint = $"{issuer.WithoutTrailingSlash()}/oauth2/authorize"
             });
         }
     }

--- a/source/Server.Extensibility.Authentication.OctopusID/OctopusIdConfigDiscoverer.cs
+++ b/source/Server.Extensibility.Authentication.OctopusID/OctopusIdConfigDiscoverer.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
+
+namespace Octopus.Server.Extensibility.Authentication.OctopusID
+{
+    public class OctopusIdConfigDiscoverer : IIdentityProviderConfigDiscoverer
+    {
+        public Task<IssuerConfiguration> GetConfigurationAsync(string issuer)
+        {
+            return Task.FromResult(new IssuerConfiguration()
+            {
+                Issuer = issuer + "/", // NOTE: the trailing / is important!
+                AuthorizationEndpoint = issuer + "/oauth2/authorize"
+            });
+        }
+    }
+}

--- a/source/Server.Extensibility.Authentication.OctopusID/StringExtensions.cs
+++ b/source/Server.Extensibility.Authentication.OctopusID/StringExtensions.cs
@@ -1,0 +1,15 @@
+namespace Octopus.Server.Extensibility.Authentication.OctopusID
+{
+    public static class StringExtensions
+    {
+        public static string WithTrailingSlash(this string uri)
+        {
+            return $"{uri.TrimEnd('/')}/";
+        }
+        
+        public static string WithoutTrailingSlash(this string uri)
+        {
+            return uri.TrimEnd('/');
+        }
+    }
+}

--- a/source/Server.Extensibility.Authentication.OctopusID/Tokens/OctopusIDAuthTokenHandler.cs
+++ b/source/Server.Extensibility.Authentication.OctopusID/Tokens/OctopusIDAuthTokenHandler.cs
@@ -6,9 +6,9 @@ using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
 
 namespace Octopus.Server.Extensibility.Authentication.OctopusID.Tokens
 {
-    public class OctopusIDAuthTokenHandler : OpenIDConnectAuthTokenWithRolesHandler<IOctopusIDConfigurationStore, IOctopusIDKeyRetriever>, IOctopusIDAuthTokenHandler
+    public class OctopusIDAuthTokenHandler : OpenIDConnectAuthTokenWithRolesHandler<IOctopusIDConfigurationStore, IOctopusIDKeyRetriever, IOctopusIdentityProviderConfigDiscoverer>, IOctopusIDAuthTokenHandler
     {
-        public OctopusIDAuthTokenHandler(ILog log, IOctopusIDConfigurationStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IOctopusIDKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
+        public OctopusIDAuthTokenHandler(ILog log, IOctopusIDConfigurationStore configurationStore, IOctopusIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IOctopusIDKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
         {
         }
     }

--- a/source/Server.Extensibility.Authentication.OctopusID/Web/OctopusIDUserAuthenticationAction.cs
+++ b/source/Server.Extensibility.Authentication.OctopusID/Web/OctopusIDUserAuthenticationAction.cs
@@ -13,7 +13,7 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Web
         public OctopusIDUserAuthenticationAction(
             ILog log,
             IOctopusIDConfigurationStore configurationStore, 
-            IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, 
+            IOctopusIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, 
             IOctopusIDAuthorizationEndpointUrlBuilder urlBuilder,
             IApiActionModelBinder modelBinder,
             IAuthenticationConfigurationStore authenticationConfigurationStore) : base(log, configurationStore, identityProviderConfigDiscoverer, urlBuilder, modelBinder, authenticationConfigurationStore)

--- a/source/Server.Extensibility.Authentication.Okta/OktaExtension.cs
+++ b/source/Server.Extensibility.Authentication.Okta/OktaExtension.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect;
 using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Certificates;
+using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.Extensions.Identities;
 using Octopus.Server.Extensibility.Extensions.Infrastructure;
@@ -24,6 +25,8 @@ namespace Octopus.Server.Extensibility.Authentication.Okta
         public override void Load(ContainerBuilder builder)
         {
             base.Load(builder);
+            
+            builder.RegisterType<IdentityProviderConfigDiscoverer>().As<IIdentityProviderConfigDiscoverer>().SingleInstance();
 
             builder.RegisterType<OktaDatabaseInitializer>().As<IExecuteWhenDatabaseInitializes>().InstancePerDependency();
             builder.RegisterType<OktaPrincipalToUserResourceMapper>().As<IOktaPrincipalToUserResourceMapper>().InstancePerDependency();

--- a/source/Server.Extensibility.Authentication.Okta/Tokens/OktaAuthTokenHandler.cs
+++ b/source/Server.Extensibility.Authentication.Okta/Tokens/OktaAuthTokenHandler.cs
@@ -6,7 +6,7 @@ using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens;
 
 namespace Octopus.Server.Extensibility.Authentication.Okta.Tokens
 {
-    public class OktaAuthTokenHandler : OpenIDConnectAuthTokenWithRolesHandler<IOktaConfigurationStore, IOktaKeyRetriever>, IOktaAuthTokenHandler
+    public class OktaAuthTokenHandler : OpenIDConnectAuthTokenWithRolesHandler<IOktaConfigurationStore, IOktaKeyRetriever, IIdentityProviderConfigDiscoverer>, IOktaAuthTokenHandler
     {
         public OktaAuthTokenHandler(ILog log, IOktaConfigurationStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, IOktaKeyRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
         {

--- a/source/Server.Extensibility.Authentication.OpenIDConnect/Tokens/OpenIDConnectAuthTokenHandler.cs
+++ b/source/Server.Extensibility.Authentication.OpenIDConnect/Tokens/OpenIDConnectAuthTokenHandler.cs
@@ -8,14 +8,15 @@ using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Tokens;
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens
 {
-    public abstract class OpenIDConnectAuthTokenHandler<TStore, TRetriever> : AuthTokenHandler<TStore, TRetriever>, IAuthTokenHandler
+    public abstract class OpenIDConnectAuthTokenHandler<TStore, TRetriever, TDiscoverer> : AuthTokenHandler<TStore, TRetriever, TDiscoverer>, IAuthTokenHandler
         where TStore : IOpenIDConnectConfigurationStore
         where TRetriever : IKeyRetriever
+        where TDiscoverer : IIdentityProviderConfigDiscoverer
     {
         protected OpenIDConnectAuthTokenHandler(
             ILog log,
             TStore configurationStore,
-            IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer,
+            TDiscoverer identityProviderConfigDiscoverer,
             TRetriever keyRetriever) : base(configurationStore, identityProviderConfigDiscoverer, keyRetriever, log)
         {
         }

--- a/source/Server.Extensibility.Authentication.OpenIDConnect/Tokens/OpenIDConnectAuthTokenWithRolesHandler.cs
+++ b/source/Server.Extensibility.Authentication.OpenIDConnect/Tokens/OpenIDConnectAuthTokenWithRolesHandler.cs
@@ -8,11 +8,12 @@ using Octopus.Node.Extensibility.Authentication.OpenIDConnect.Issuer;
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Tokens
 {
-    public abstract class OpenIDConnectAuthTokenWithRolesHandler<TStore, TRetriever> : OpenIDConnectAuthTokenHandler<TStore, TRetriever>
+    public abstract class OpenIDConnectAuthTokenWithRolesHandler<TStore, TRetriever, TDiscoverer> : OpenIDConnectAuthTokenHandler<TStore, TRetriever, TDiscoverer>
         where TStore : IOpenIDConnectConfigurationWithRoleStore
         where TRetriever : IKeyRetriever
+        where TDiscoverer : IIdentityProviderConfigDiscoverer
     {
-        protected OpenIDConnectAuthTokenWithRolesHandler(ILog log, TStore configurationStore, IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer, TRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
+        protected OpenIDConnectAuthTokenWithRolesHandler(ILog log, TStore configurationStore, TDiscoverer identityProviderConfigDiscoverer, TRetriever keyRetriever) : base(log, configurationStore, identityProviderConfigDiscoverer, keyRetriever)
         {
         }
 


### PR DESCRIPTION
## Context
As discussed [via Slack](https://octopusdeploy.slack.com/archives/CLF5AF83V/p1568247917034200):

1. We want to write a mega-end-to-end test that covers the interaction between a provisioned Cloud v2 instance and Octopus ID SSO
2. We want that test to run against an in-memory instance of `Octofront.Web.Hosted` (for provisioning) and `Octofront.Web.Public` (for Octopus ID SSO)

## Problem
We cannot write such a test, because the provisioned Cloud v2 instance attempts to place a request to the identity provider at `localhost/.well-known/openid-configuration` but of course, in that context, `localhost`  is the Cloud instance's host in Azure, not the test runner, so the request fails.

### Solution 1
Find a way to allow Server to place the request directly to `localhost`, by integrating something like `ngrok` into the test runner process.
• Pros: [marginal]: If we switch to using a non-HMAC JWT algorithm _in future_, we'd be able to make that change in Octofront rather than Server.
• Cons: More complex than Solution 2, and test is more likely to be flaky. Not too keen on spawning an `ngrok` process from within a fairly long-running test run.

### Solution 2
Change the Octopus ID auth extension so that it no longer attempts to make a call to `localhost/.well-known/openid-configuration`; instead, we _inline_ the well known configuration into the auth extension itself.

• Pros: No need to use `ngrok` anymore, during development or during testing! :simples: We wouldn't need to inline much at all, as our config is currently pretty much empty (https://github.com/OctopusDeploy/Octofront/blob/master/source/Octofront.Web.Public/Controllers/WellKnownConfigurationController.cs#L18)
• Cons: We'd likely want to bring back `/.well-known/openid-configuration` before we started to support self-hosted instances, and would probably have to bite the `ngrok` bullet at that point (maybe not a "con", just an acknowledgement that this simple solution may not cut it forever).

## This PR
Implements Solution 2 from above.

## Checklist
- [x] Manual test