### PR TITLE
Hide the Octopus ID command line configuration options

### DIFF
--- a/source/Server.Extensibility.Authentication.OctopusID/Configuration/OctopusIDConfigureCommands.cs
+++ b/source/Server.Extensibility.Authentication.OctopusID/Configuration/OctopusIDConfigureCommands.cs
@@ -21,7 +21,7 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
 
         public override IEnumerable<ConfigureCommandOption> GetOptions()
         {
-            foreach (var option in base.GetOptions())
+            foreach (var option in base.GetCoreOptions(hide: true))
             {
                 yield return option;
             }
@@ -29,7 +29,7 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
             {
                 ConfigurationStore.Value.SetClientSecret(v);
                 Log.Info($"{ConfigurationSettingsName} ClientSecret set");
-            });
+            }, hide: true);
         }
     }
 }

--- a/source/Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigureCommands.cs
+++ b/source/Server.Extensibility.Authentication.OpenIDConnect/Configuration/OpenIDConnectConfigureCommands.cs
@@ -27,7 +27,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuratio
 
         protected abstract string ConfigurationSettingsName { get; }
 
-        public virtual IEnumerable<ConfigureCommandOption> GetOptions()
+        protected IEnumerable<ConfigureCommandOption> GetCoreOptions(bool hide)
         {
             yield return new ConfigureCommandOption($"{ConfigurationSettingsName}IsEnabled=", $"Set the {ConfigurationSettingsName} IsEnabled, used for authentication.", v =>
             {
@@ -51,17 +51,25 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Configuratio
                         Log.Info(prefix.TrimEnd('/') + "/api/users/authenticatedToken/" + ConfigurationStore.Value.ConfigurationSettingsName);
                     }
                 }
-            });
+            }, hide: hide);
             yield return new ConfigureCommandOption($"{ConfigurationSettingsName}Issuer=", $"Follow our documentation to find the Issuer for {ConfigurationSettingsName}.", v =>
             {
                 ConfigurationStore.Value.SetIssuer(v);
                 Log.Info($"{ConfigurationSettingsName} Issuer set to: {v}");
-            });
+            }, hide: hide);
             yield return new ConfigureCommandOption($"{ConfigurationSettingsName}ClientId=", $"Follow our documentation to find the Client ID for {ConfigurationSettingsName}.", v =>
             {
                 ConfigurationStore.Value.SetClientId(v);
                 Log.Info($"{ConfigurationSettingsName} ClientId set to: {v}");
-            });
+            }, hide: hide);
+        }
+
+        public virtual IEnumerable<ConfigureCommandOption> GetOptions()
+        {
+            foreach (var option in GetCoreOptions(hide: false))
+            {
+                yield return option;
+            }
             yield return new ConfigureCommandOption($"{ConfigurationSettingsName}Scope=", $"Only change this if you need to change the OpenID Connect scope requested by Octopus for {ConfigurationSettingsName}.", v =>
             {
                 ConfigurationStore.Value.SetScope(v);


### PR DESCRIPTION
If the Octopus ID options aren't hidden then they appear for `octopus.server.exe configure --help`, which also means they appear automatically in the docs, which we'd rather not have.

These command are still available, they are just hidden from the users.

Following is the updated output of the configure command help
![image](https://user-images.githubusercontent.com/4229735/64934641-79638900-d88f-11e9-8d7f-26ee5c7bfe81.png)

Following is output from changing the Octopus ID enabled state (the warning is expected, based on the config I have setup)
![image](https://user-images.githubusercontent.com/4229735/64934687-c34c6f00-d88f-11e9-97fd-9840bcf45421.png)

