### PR TITLE
fix(identity): Display names are not an identifying claim for external identities

### DIFF
--- a/source/Node.Extensibility.Authentication.OpenIDConnect/Identities/IdentityCreator.cs
+++ b/source/Node.Extensibility.Authentication.OpenIDConnect/Identities/IdentityCreator.cs
@@ -13,7 +13,7 @@ namespace Octopus.Node.Extensibility.Authentication.OpenIDConnect.Identities
         {
             return new Identity(ProviderName)
                 .WithClaim(ClaimDescriptor.EmailClaimType, email, true)
-                .WithClaim(ClaimDescriptor.DisplayNameClaimType, displayName, true)
+                .WithClaim(ClaimDescriptor.DisplayNameClaimType, displayName, false)
                 .WithClaim(ExternalIdClaimType, externalId, true, true);
         }
     }


### PR DESCRIPTION
## Context
When a user logs in via an external auth provider (Google, Octopus ID, etc), we look at existing Octopus users and decide if any match and should be linked.

## This PR
This PR ensures that we _do not_ match and link based on the _display name_ of existing users.
This PR brings the behavior for new identities into line with [the way we display external logins in the UI](https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders/blob/master/source/Node.Extensibility.Authentication.OpenIDConnect/OpenIDConnectAuthenticationProvider.cs#L100), so it's likely this was always the intention and this is just a straight up bug

## How to review
- [ ] Do we need to/should we write a migration for existing identities?