### PR TITLE
Update Hover colours on OctopusID Sign In screen

### DIFF
--- a/source/Server.Extensibility.Authentication.OctopusID/Web/Static/areas/users/octopusId_auth_provider.js
+++ b/source/Server.Extensibility.Authentication.OctopusID/Web/Static/areas/users/octopusId_auth_provider.js
@@ -2,7 +2,7 @@
 
 function octopusIDAuthProvider(octopusClient, provider, loginState, onError) {
 
-    this.linkHtml = '<a><div class="octopusID-button"><img src="' + octopusClient.resolve("~/images/Octopus-96x96.png") + '" /><div>Sign in with your Octopus ID</div></div></a>';
+    this.linkHtml = '<a><div class="octopusID-button"><div><em class="fontoctopus-octopus" style="font-size:23px; margin-right:10px;"></em> Sign in with your Octopus ID</div></div></a>';
 
     this.signIn = function () {
         console.log("Signing in using " + providerName + " provider");

--- a/source/Server.Extensibility.Authentication.OctopusID/Web/Static/styles/octopusId.css
+++ b/source/Server.Extensibility.Authentication.OctopusID/Web/Static/styles/octopusId.css
@@ -10,14 +10,14 @@
 }
 
 .octopusID-button:hover {
-    background-color: #4a4a4a;
+    background-color: #2F93E0;
+    color: #fff;
 }
 
 .octopusID-button img {
     margin-left: 0.8125rem;
     width: 23px;
     height: 22px;
-    background-color: #fafafa;
     -webkit-border-radius: 1px;
     -moz-border-radius: 1px;
     border-radius: 1px;


### PR DESCRIPTION
I've updated the background colour and text colour on the **Sign in with your Octopus ID** button.  I've also swapped out the PNG we were using for the font version of our logo to easily switch colours on hover.

**Here's the aim:**
![Sign_In_with_your_Octopus_ID](https://user-images.githubusercontent.com/42991018/66982318-1c126000-f0f9-11e9-9014-d67261959e23.png)

Related to Trello card: https://trello.com/c/1YaP8ofQ/79-hover-state-on-button-is-too-dark

Please check and review that I haven't broken anything, and it looks like the design above.  Thanks