### PR TITLE
Bug octopus id button

### DIFF
--- a/source/Server.OctopusID/Web/Static/styles/octopusId.css
+++ b/source/Server.OctopusID/Web/Static/styles/octopusId.css
@@ -7,10 +7,12 @@
     align-items: center;
     padding-top: 0.8125rem;
     padding-bottom: 0.8125rem;
+    background-color: #54B954;
+    color: #fff;
 }
 
 .octopusID-button:hover {
-    background-color: #2F93E0;
+    background-color: #449744;
     color: #fff;
 }
 
@@ -24,7 +26,7 @@
 }
 
 .octopusID-button div {
-    font-weight: 600;
+    font-weight: 500;
     display: inline-block;
     text-align: left;
     margin-left: 0.8125rem;

--- a/source/Server.OctopusID/Web/Static/styles/octopusId.css
+++ b/source/Server.OctopusID/Web/Static/styles/octopusId.css
@@ -26,7 +26,7 @@
 }
 
 .octopusID-button div {
-    font-weight: 500;
+    font-weight: 400;
     display: inline-block;
     text-align: left;
     margin-left: 0.8125rem;


### PR DESCRIPTION
The Octopus ID button had no background color and it blended into the background.

## Before
![image](https://user-images.githubusercontent.com/17240784/75400814-0c7b1180-594c-11ea-97a7-d393db32b894.png)
![image](https://user-images.githubusercontent.com/17240784/75400832-1866d380-594c-11ea-9986-927a2d515bad.png)

## After
<img width="414" alt="Screen Shot 2020-02-27 at 10 14 56 am" src="https://user-images.githubusercontent.com/17240784/75400802-05540380-594c-11ea-8a6f-ba6931b67b15.png">
<img width="394" alt="Screen Shot 2020-02-27 at 10 13 43 am" src="https://user-images.githubusercontent.com/17240784/75400805-07b65d80-594c-11ea-8e86-5dbf170dd577.png">