### PR TITLE
Enabling Nullable Reference Types

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -23,7 +23,7 @@ var artifactsDir = "./artifacts";
 var assetDir = "./BuildAssets";
 var solutionToBuild = "./source/OpenIDConnectAuthenticationProvider.sln";
 
-var bin = "/bin/Release/netstandard2.0/";
+var bin = "/bin/Release/netstandard2.1/";
 
 var gitVersionInfo = GitVersion(new GitVersionSettings {
     OutputType = GitVersionOutput.Json

--- a/source/Server.AzureAD/Configuration/AzureADConfigurationResource.cs
+++ b/source/Server.AzureAD/Configuration/AzureADConfigurationResource.cs
@@ -10,6 +10,6 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD.Configuration
         [DisplayName("Role Claim Type")]
         [Description("Tell Octopus how to find the roles/groups in the security token from Azure Active Directory (usually \"roles\" or \"groups\")")]
         [Writeable]
-        public string RoleClaimType { get; set; }
+        public string? RoleClaimType { get; set; }
     }
 }

--- a/source/Server.AzureAD/Configuration/AzureADConfigurationSettings.cs
+++ b/source/Server.AzureAD/Configuration/AzureADConfigurationSettings.cs
@@ -20,7 +20,7 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD.Configuration
             {
                 yield return configurationValue;
             }
-            yield return new ConfigurationValue<string>($"Octopus.{ConfigurationDocumentStore.ConfigurationSettingsName}.RoleClaimType", ConfigurationDocumentStore.GetRoleClaimType(), ConfigurationDocumentStore.GetIsEnabled() && ConfigurationDocumentStore.GetRoleClaimType() != AzureADConfiguration.DefaultRoleClaimType, "Role Claim Type");
+            yield return new ConfigurationValue<string?>($"Octopus.{ConfigurationDocumentStore.ConfigurationSettingsName}.RoleClaimType", ConfigurationDocumentStore.GetRoleClaimType(), ConfigurationDocumentStore.GetIsEnabled() && ConfigurationDocumentStore.GetRoleClaimType() != AzureADConfiguration.DefaultRoleClaimType, "Role Claim Type");
         }
 
     }

--- a/source/Server.AzureAD/Infrastructure/AzureADPrincipalToUserResourceMapper.cs
+++ b/source/Server.AzureAD/Infrastructure/AzureADPrincipalToUserResourceMapper.cs
@@ -5,13 +5,13 @@ namespace Octopus.Server.Extensibility.Authentication.AzureAD.Infrastructure
 {
     class AzureADPrincipalToUserResourceMapper : PrincipalToUserResourceMapper, IAzureADPrincipalToUserResourceMapper
     {
-        protected override string GetEmailAddress(ClaimsPrincipal principal)
+        protected override string? GetEmailAddress(ClaimsPrincipal principal)
         {
             // Grab the email address if it exists as a claim, otherwise get the UPN as a good fallback
             return base.GetEmailAddress(principal) ?? GetClaimValue(principal, ClaimTypes.Upn);
         }
 
-        protected override string GetUsername(ClaimsPrincipal principal)
+        protected override string? GetUsername(ClaimsPrincipal principal)
         {
             // Use the UPN in preference for username
             return GetClaimValue(principal, ClaimTypes.Upn) ?? base.GetUsername(principal);

--- a/source/Server.AzureAD/Server.AzureAD.csproj
+++ b/source/Server.AzureAD/Server.AzureAD.csproj
@@ -11,10 +11,11 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders</PackageProjectUrl>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server.AzureAD/Server.AzureAD.csproj
+++ b/source/Server.AzureAD/Server.AzureAD.csproj
@@ -2,18 +2,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Octopus.Server.Extensibility.Authentication.AzureAD</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication.AzureAD</AssemblyName>
     <Description>Octopus Deploy: Extensibility.Authentication.AzureAD</Description>
     <Authors>Octopus Deploy</Authors>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
-    <PackageLicenseUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders</PackageProjectUrl>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server.AzureAD/Server.AzureAD.csproj
+++ b/source/Server.AzureAD/Server.AzureAD.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server.GoogleApps/Configuration/GoogleAppsConfiguration.cs
+++ b/source/Server.GoogleApps/Configuration/GoogleAppsConfiguration.cs
@@ -9,6 +9,6 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration
             Issuer = "https://accounts.google.com";
         }
 
-        public string HostedDomain { get; set; }
+        public string? HostedDomain { get; set; }
     }
 }

--- a/source/Server.GoogleApps/Configuration/GoogleAppsConfigurationResource.cs
+++ b/source/Server.GoogleApps/Configuration/GoogleAppsConfigurationResource.cs
@@ -10,6 +10,6 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration
         [DisplayName("Hosted Domain")]
         [Description("Tell Octopus which Google Apps domain to trust")]
         [Writeable]
-        public string HostedDomain { get; set; }
+        public string? HostedDomain { get; set; }
     }
 }

--- a/source/Server.GoogleApps/Configuration/GoogleAppsConfigurationSettings.cs
+++ b/source/Server.GoogleApps/Configuration/GoogleAppsConfigurationSettings.cs
@@ -20,7 +20,7 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration
                 yield return configurationValue;
             }
 
-            yield return new ConfigurationValue<string>($"Octopus.{ConfigurationDocumentStore.ConfigurationSettingsName}.HostedDomain", ConfigurationDocumentStore.GetHostedDomain(), ConfigurationDocumentStore.GetIsEnabled(), "Hosted Domain");
+            yield return new ConfigurationValue<string?>($"Octopus.{ConfigurationDocumentStore.ConfigurationSettingsName}.HostedDomain", ConfigurationDocumentStore.GetHostedDomain(), ConfigurationDocumentStore.GetIsEnabled(), "Hosted Domain");
         }
     }
 }

--- a/source/Server.GoogleApps/Configuration/GoogleAppsConfigurationStore.cs
+++ b/source/Server.GoogleApps/Configuration/GoogleAppsConfigurationStore.cs
@@ -15,12 +15,12 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration
         {
         }
 
-        public string GetHostedDomain()
+        public string? GetHostedDomain()
         {
             return GetProperty(doc => doc.HostedDomain);
         }
 
-        public void SetHostedDomain(string hostedDomain)
+        public void SetHostedDomain(string? hostedDomain)
         {
             SetProperty(doc => doc.HostedDomain = hostedDomain);
         }

--- a/source/Server.GoogleApps/Configuration/IGoogleAppsConfigurationStore.cs
+++ b/source/Server.GoogleApps/Configuration/IGoogleAppsConfigurationStore.cs
@@ -4,7 +4,7 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Configuration
 {
     interface IGoogleAppsConfigurationStore : IOpenIDConnectConfigurationStore<GoogleAppsConfiguration>
     {
-        string GetHostedDomain();
-        void SetHostedDomain(string hostedDomain);
+        string? GetHostedDomain();
+        void SetHostedDomain(string? hostedDomain);
     }
 }

--- a/source/Server.GoogleApps/Issuer/GoogleAppsAuthorizationEndpointUrlBuilder.cs
+++ b/source/Server.GoogleApps/Issuer/GoogleAppsAuthorizationEndpointUrlBuilder.cs
@@ -11,7 +11,7 @@ namespace Octopus.Server.Extensibility.Authentication.GoogleApps.Issuer
         {
         }
 
-        public override string Build(string requestDirectoryPath, IssuerConfiguration issuerConfiguration, string nonce, string state = null)
+        public override string Build(string requestDirectoryPath, IssuerConfiguration issuerConfiguration, string nonce, string? state = null)
         {
             var url = base.Build(requestDirectoryPath, issuerConfiguration, nonce, state);
 

--- a/source/Server.GoogleApps/Server.GoogleApps.csproj
+++ b/source/Server.GoogleApps/Server.GoogleApps.csproj
@@ -2,14 +2,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Octopus.Server.Extensibility.Authentication.GoogleApps</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication.GoogleApps</AssemblyName>
     <Description>Octopus Deploy: Extensibility.Authentication.GoogleApps</Description>
     <Authors>Octopus Deploy</Authors>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
-    <PackageLicenseUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders</PackageProjectUrl>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Server.GoogleApps/Server.GoogleApps.csproj
+++ b/source/Server.GoogleApps/Server.GoogleApps.csproj
@@ -11,6 +11,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders</PackageProjectUrl>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Server.OctopusID/Configuration/OctopusIDConfiguration.cs
+++ b/source/Server.OctopusID/Configuration/OctopusIDConfiguration.cs
@@ -13,6 +13,6 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
             RoleClaimType = DefaultRoleClaimType;
         }
         
-        public string RoleClaimType { get; set; }
+        public string? RoleClaimType { get; set; }
     }
 }

--- a/source/Server.OctopusID/Configuration/OctopusIDConfigurationResource.cs
+++ b/source/Server.OctopusID/Configuration/OctopusIDConfigurationResource.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel;
 using Octopus.Data.Resources;
-using Octopus.Data.Resources.Attributes;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Configuration;
 
 namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
@@ -9,16 +8,16 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
     class OctopusIDConfigurationResource : OpenIDConnectConfigurationWithClientSecretResource
     {
         [ReadOnly(true)]
-        public override string Issuer { get; set; }
+        public override string? Issuer { get; set; }
         
         /// <summary>
         /// NOTE: the following properties are here to control the order they appear on the settings page
         /// </summary>
         
         [ReadOnly(true)]
-        public override string ClientId { get; set; }
+        public override string? ClientId { get; set; }
         [ReadOnly(true)]
-        public override SensitiveValue ClientSecret { get; set; }
+        public override SensitiveValue? ClientSecret { get; set; }
         [ReadOnly(true)]
         public override bool? AllowAutoUserCreation { get; set; }
 

--- a/source/Server.OctopusID/Configuration/OctopusIDConfigurationSettings.cs
+++ b/source/Server.OctopusID/Configuration/OctopusIDConfigurationSettings.cs
@@ -25,9 +25,9 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
             return new IConfigurationValue[]
             {
                 new ConfigurationValue<bool>($"Octopus.{configurationSettingsName}.IsEnabled", isEnabled, isEnabled, "Is Enabled"),
-                new ConfigurationValue<string>($"Octopus.{configurationSettingsName}.Issuer", ConfigurationDocumentStore.GetIssuer(), isEnabled, "Issuer"),
-                new ConfigurationValue<string>($"Octopus.{configurationSettingsName}.ClientId", ConfigurationDocumentStore.GetClientId(), isEnabled, "ClientId"),
-                new ConfigurationValue<SensitiveString>($"Octopus.{configurationSettingsName}.ClientSecret", ConfigurationDocumentStore.GetClientSecret(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetClientSecret()?.Value), "Client Secret"),
+                new ConfigurationValue<string?>($"Octopus.{configurationSettingsName}.Issuer", ConfigurationDocumentStore.GetIssuer(), isEnabled, "Issuer"),
+                new ConfigurationValue<string?>($"Octopus.{configurationSettingsName}.ClientId", ConfigurationDocumentStore.GetClientId(), isEnabled, "ClientId"),
+                new ConfigurationValue<SensitiveString?>($"Octopus.{configurationSettingsName}.ClientSecret", ConfigurationDocumentStore.GetClientSecret(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetClientSecret()?.Value), "Client Secret"),
                 new ConfigurationValue<bool>($"Octopus.{configurationSettingsName}.AllowAutoUserCreation", ConfigurationDocumentStore.GetAllowAutoUserCreation(), isEnabled, "Allow auto user creation")
             };
         }

--- a/source/Server.OctopusID/Configuration/OctopusIDConfigurationStore.cs
+++ b/source/Server.OctopusID/Configuration/OctopusIDConfigurationStore.cs
@@ -16,12 +16,12 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
         {
         }
 
-        public string GetRoleClaimType()
+        public string? GetRoleClaimType()
         {
             return GetProperty(doc => doc.RoleClaimType);
         }
 
-        public void SetRoleClaimType(string roleClaimType)
+        public void SetRoleClaimType(string? roleClaimType)
         {
             SetProperty(doc => doc.RoleClaimType = roleClaimType);
         }

--- a/source/Server.OctopusID/Server.OctopusID.csproj
+++ b/source/Server.OctopusID/Server.OctopusID.csproj
@@ -11,10 +11,11 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders</PackageProjectUrl>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server.OctopusID/Server.OctopusID.csproj
+++ b/source/Server.OctopusID/Server.OctopusID.csproj
@@ -2,18 +2,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Octopus.Server.Extensibility.Authentication.OctopusID</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication.OctopusID</AssemblyName>
     <Description>Octopus Deploy: Extensibility.Authentication.OctopusID</Description>
     <Authors>Octopus Deploy</Authors>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
-    <PackageLicenseUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders</PackageProjectUrl>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server.OctopusID/Server.OctopusID.csproj
+++ b/source/Server.OctopusID/Server.OctopusID.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server.OctopusID/Web/OctopusIDLoginParametersHandler.cs
+++ b/source/Server.OctopusID/Web/OctopusIDLoginParametersHandler.cs
@@ -15,7 +15,9 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Web
             this.configurationStore = configurationStore;
         }
 
-        public LoginInitiatedResult? WasExternalLoginInitiated(string encodedQueryString)
+        public string IdentityProviderName => OctopusIDAuthenticationProvider.ProviderName;
+
+        public bool? WasExternalLoginInitiated(string encodedQueryString)
         {
             if (!configurationStore.GetIsEnabled())
                 return null;
@@ -27,10 +29,7 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Web
 
             var configuredIssuer = configurationStore.GetIssuer();
 
-            if (issuerParam != null && string.Compare(configuredIssuer, issuerParam.Value, StringComparison.InvariantCultureIgnoreCase) == 0)
-                return new LoginInitiatedResult(OctopusIDAuthenticationProvider.ProviderName);
-
-            return null;
+            return issuerParam != null && string.Compare(configuredIssuer, issuerParam.Value, StringComparison.InvariantCultureIgnoreCase) == 0;
         }
     }
 }

--- a/source/Server.OctopusID/Web/OctopusIDLoginParametersHandler.cs
+++ b/source/Server.OctopusID/Web/OctopusIDLoginParametersHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using Octopus.CoreUtilities;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.OctopusID.Configuration;
 using Octopus.Server.Extensibility.Authentication.Web;
@@ -16,10 +15,10 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Web
             this.configurationStore = configurationStore;
         }
 
-        public Maybe<LoginInitiatedResult> WasExternalLoginInitiated(string encodedQueryString)
+        public LoginInitiatedResult? WasExternalLoginInitiated(string encodedQueryString)
         {
             if (!configurationStore.GetIsEnabled())
-                return Maybe<LoginInitiatedResult>.None;
+                return null;
 
             var parser = new EncodedQueryStringParser();
             var parameters = parser.Parse(encodedQueryString);
@@ -29,9 +28,9 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Web
             var configuredIssuer = configurationStore.GetIssuer();
 
             if (issuerParam != null && string.Compare(configuredIssuer, issuerParam.Value, StringComparison.InvariantCultureIgnoreCase) == 0)
-                return new LoginInitiatedResult(OctopusIDAuthenticationProvider.ProviderName).AsSome();
+                return new LoginInitiatedResult(OctopusIDAuthenticationProvider.ProviderName);
 
-            return Maybe<LoginInitiatedResult>.None;
+            return null;
         }
     }
 }

--- a/source/Server.Okta/Configuration/OktaConfigurationResource.cs
+++ b/source/Server.Okta/Configuration/OktaConfigurationResource.cs
@@ -10,11 +10,11 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Configuration
         [DisplayName("Role Claim Type")]
         [Description("Tell Octopus how to find the roles in the security token from Okta")]
         [Writeable]
-        public string RoleClaimType { get; set; }
+        public string? RoleClaimType { get; set; }
 
         [DisplayName("Username Claim Type")]
         [Description("Tell Octopus how to find the value for the Octopus Username in the Okta token. Defaults to \"preferred_username\" if left blank.")]
         [Writeable]
-        public string UsernameClaimType { get; set; }
+        public string? UsernameClaimType { get; set; }
     }
 }

--- a/source/Server.Okta/Configuration/OktaConfigurationSettings.cs
+++ b/source/Server.Okta/Configuration/OktaConfigurationSettings.cs
@@ -19,8 +19,8 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Configuration
             {
                 yield return configurationValue;
             }
-            yield return new ConfigurationValue<string>($"Octopus.{ConfigurationDocumentStore.ConfigurationSettingsName}.RoleClaimType", ConfigurationDocumentStore.GetRoleClaimType(), ConfigurationDocumentStore.GetIsEnabled() && ConfigurationDocumentStore.GetRoleClaimType() != OktaConfiguration.DefaultRoleClaimType, "Role Claim Type");
-            yield return new ConfigurationValue<string>($"Octopus.{ConfigurationDocumentStore.ConfigurationSettingsName}.UsernameClaimType", ConfigurationDocumentStore.GetUsernameClaimType(), ConfigurationDocumentStore.GetIsEnabled() && ConfigurationDocumentStore.GetUsernameClaimType() != OktaConfiguration.DefaultUsernameClaimType, "Username Claim Type");
+            yield return new ConfigurationValue<string?>($"Octopus.{ConfigurationDocumentStore.ConfigurationSettingsName}.RoleClaimType", ConfigurationDocumentStore.GetRoleClaimType(), ConfigurationDocumentStore.GetIsEnabled() && ConfigurationDocumentStore.GetRoleClaimType() != OktaConfiguration.DefaultRoleClaimType, "Role Claim Type");
+            yield return new ConfigurationValue<string?>($"Octopus.{ConfigurationDocumentStore.ConfigurationSettingsName}.UsernameClaimType", ConfigurationDocumentStore.GetUsernameClaimType(), ConfigurationDocumentStore.GetIsEnabled() && ConfigurationDocumentStore.GetUsernameClaimType() != OktaConfiguration.DefaultUsernameClaimType, "Username Claim Type");
         }
     }
 }

--- a/source/Server.Okta/Infrastructure/OktaPrincipalToUserResourceMapper.cs
+++ b/source/Server.Okta/Infrastructure/OktaPrincipalToUserResourceMapper.cs
@@ -13,13 +13,13 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Infrastructure
             this.configurationStore = configurationStore;
         }
 
-        protected override string GetEmailAddress(ClaimsPrincipal principal)
+        protected override string? GetEmailAddress(ClaimsPrincipal principal)
         {
             // Grab the email address if it exists as a claim, otherwise get the UPN as a good fallback
             return base.GetEmailAddress(principal) ?? GetClaimValue(principal, ClaimTypes.Upn);
         }
 
-        protected override string GetUsername(ClaimsPrincipal principal)
+        protected override string? GetUsername(ClaimsPrincipal principal)
         {
             // Use the UPN in preference for username
             return GetClaimValue(principal, configurationStore.GetUsernameClaimType()) ?? base.GetUsername(principal);

--- a/source/Server.Okta/Server.Okta.csproj
+++ b/source/Server.Okta/Server.Okta.csproj
@@ -11,10 +11,11 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders</PackageProjectUrl>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server.Okta/Server.Okta.csproj
+++ b/source/Server.Okta/Server.Okta.csproj
@@ -2,18 +2,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Octopus.Server.Extensibility.Authentication.Okta</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication.Okta</AssemblyName>
     <Description>Octopus Deploy: Extensibility.Authentication.Okta</Description>
     <Authors>Octopus Deploy</Authors>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
-    <PackageLicenseUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders</PackageProjectUrl>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server.Okta/Server.Okta.csproj
+++ b/source/Server.Okta/Server.Okta.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server.Okta/Web/OktaLoginParametersHandler.cs
+++ b/source/Server.Okta/Web/OktaLoginParametersHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using Octopus.CoreUtilities;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.Okta.Configuration;
 using Octopus.Server.Extensibility.Authentication.Web;
@@ -16,10 +15,10 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Web
             this.configurationStore = configurationStore;
         }
 
-        public Maybe<LoginInitiatedResult> WasExternalLoginInitiated(string encodedQueryString)
+        public LoginInitiatedResult? WasExternalLoginInitiated(string encodedQueryString)
         {
             if (!configurationStore.GetIsEnabled())
-                return Maybe<LoginInitiatedResult>.None;
+                return null;
 
             var parser = new EncodedQueryStringParser();
             var parameters = parser.Parse(encodedQueryString);
@@ -29,9 +28,9 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Web
             var configuredIssuer = configurationStore.GetIssuer();
 
             if (issuerParam != null && string.Compare(configuredIssuer, issuerParam.Value, StringComparison.InvariantCultureIgnoreCase) == 0)
-                return new LoginInitiatedResult(OktaAuthenticationProvider.ProviderName).AsSome();
+                return new LoginInitiatedResult(OktaAuthenticationProvider.ProviderName);
 
-            return Maybe<LoginInitiatedResult>.None;
+            return null;
         }
     }
 }

--- a/source/Server.Okta/Web/OktaLoginParametersHandler.cs
+++ b/source/Server.Okta/Web/OktaLoginParametersHandler.cs
@@ -15,7 +15,9 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Web
             this.configurationStore = configurationStore;
         }
 
-        public LoginInitiatedResult? WasExternalLoginInitiated(string encodedQueryString)
+        public string IdentityProviderName => OktaAuthenticationProvider.ProviderName;
+
+        public bool? WasExternalLoginInitiated(string encodedQueryString)
         {
             if (!configurationStore.GetIsEnabled())
                 return null;
@@ -27,10 +29,7 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Web
 
             var configuredIssuer = configurationStore.GetIssuer();
 
-            if (issuerParam != null && string.Compare(configuredIssuer, issuerParam.Value, StringComparison.InvariantCultureIgnoreCase) == 0)
-                return new LoginInitiatedResult(OktaAuthenticationProvider.ProviderName);
-
-            return null;
+            return issuerParam != null && string.Compare(configuredIssuer, issuerParam.Value, StringComparison.InvariantCultureIgnoreCase) == 0;
         }
     }
 }

--- a/source/Server.OpenIDConnect.Common/Certificates/CertificateDetails.cs
+++ b/source/Server.OpenIDConnect.Common/Certificates/CertificateDetails.cs
@@ -2,6 +2,6 @@
 {
     public class CertificateDetails : KeyDetails
     {
-        public string Certificate { get; set; }
+        public string Certificate { get; set; } = string.Empty;
     }
 }

--- a/source/Server.OpenIDConnect.Common/Certificates/DefaultKeyJsonParser.cs
+++ b/source/Server.OpenIDConnect.Common/Certificates/DefaultKeyJsonParser.cs
@@ -50,28 +50,28 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Certi
 
         public class IssuerKeys
         {
-            public List<IssuerKey> Keys { get; set; }
+            public List<IssuerKey> Keys { get; set; } = new List<IssuerKey>();
         }
 
         public class IssuerKey
         {
             [JsonProperty("kty")]
-            public string KeyType { get; set; }
+            public string KeyType { get; set; } = string.Empty;
 
             [JsonProperty("use")]
-            public string PublicKeyUse { get; set; }
+            public string PublicKeyUse { get; set; } = string.Empty;
 
             [JsonProperty("kid")]
-            public string KeyId { get; set; }
+            public string KeyId { get; set; } = string.Empty;
 
             [JsonProperty("e")]
-            public string Exponent { get; set; }
+            public string? Exponent { get; set; }
 
             [JsonProperty("n")]
-            public string Modulus { get; set; }
+            public string? Modulus { get; set; }
 
             [JsonProperty("x5c")]
-            public string[] x509Chain { get; set; }
+            public string[]? x509Chain { get; set; }
         }
     }
 }

--- a/source/Server.OpenIDConnect.Common/Certificates/KeyDetails.cs
+++ b/source/Server.OpenIDConnect.Common/Certificates/KeyDetails.cs
@@ -2,6 +2,6 @@
 {
     public class KeyDetails
     {
-        public string Kid { get; set; }
+        public string Kid { get; set; } = string.Empty;
     }
 }

--- a/source/Server.OpenIDConnect.Common/Certificates/KeyRetriever.cs
+++ b/source/Server.OpenIDConnect.Common/Certificates/KeyRetriever.cs
@@ -20,7 +20,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Certi
         readonly TKeyParser keyParser;
         readonly ILog log;
         readonly object funcLock = new object();
-        Task<IDictionary<string, AsymmetricSecurityKey>> certRetrieveTask;
+        Task<IDictionary<string, AsymmetricSecurityKey>>? certRetrieveTask;
 
         protected readonly TStore ConfigurationStore;
 

--- a/source/Server.OpenIDConnect.Common/Certificates/RsaDetails.cs
+++ b/source/Server.OpenIDConnect.Common/Certificates/RsaDetails.cs
@@ -2,7 +2,7 @@
 {
     public class RsaDetails : KeyDetails
     {
-        public string Modulus { get; set; }
-        public string Exponent { get; set; }
+        public string Modulus { get; set; } = string.Empty;
+        public string Exponent { get; set; } = string.Empty;
     }
 }

--- a/source/Server.OpenIDConnect.Common/Configuration/IOpenIDConnectConfiguration.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/IOpenIDConnectConfiguration.cs
@@ -2,10 +2,10 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
 {
     public interface IOpenIDConnectConfiguration
     {
-        string Issuer { get; set; }
-        string ClientId { get; set; }
-        string Scope { get; set; }
-        string NameClaimType { get; set; }
+        string? Issuer { get; set; }
+        string? ClientId { get; set; }
+        string? Scope { get; set; }
+        string? NameClaimType { get; set; }
         bool AllowAutoUserCreation { get; set; }
     }
 }

--- a/source/Server.OpenIDConnect.Common/Configuration/IOpenIDConnectConfigurationStore.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/IOpenIDConnectConfigurationStore.cs
@@ -12,17 +12,17 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
     {
         string ConfigurationSettingsName { get; }
 
-        string GetIssuer();
-        void SetIssuer(string issuer);
+        string? GetIssuer();
+        void SetIssuer(string? issuer);
 
-        string GetClientId();
-        void SetClientId(string clientId);
+        string? GetClientId();
+        void SetClientId(string? clientId);
 
-        string GetScope();
-        void SetScope(string scope);
+        string? GetScope();
+        void SetScope(string? scope);
 
-        string GetNameClaimType();
-        void SetNameClaimType(string nameClaimType);
+        string? GetNameClaimType();
+        void SetNameClaimType(string? nameClaimType);
 
         string RedirectUri { get; }
 

--- a/source/Server.OpenIDConnect.Common/Configuration/IOpenIDConnectConfigurationWithClientSecret.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/IOpenIDConnectConfigurationWithClientSecret.cs
@@ -4,6 +4,6 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
 {
     public interface IOpenIDConnectConfigurationWithClientSecret : IOpenIDConnectConfiguration
     {
-        SensitiveString ClientSecret { get; set; }       
+        SensitiveString? ClientSecret { get; set; }       
     }
 }

--- a/source/Server.OpenIDConnect.Common/Configuration/IOpenIDConnectConfigurationWithRole.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/IOpenIDConnectConfigurationWithRole.cs
@@ -2,6 +2,6 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
 {
     public interface IOpenIDConnectConfigurationWithRole : IOpenIDConnectConfiguration
     {
-        string RoleClaimType { get; set; }       
+        string? RoleClaimType { get; set; }       
     }
 }

--- a/source/Server.OpenIDConnect.Common/Configuration/IOpenIDConnectConfigurationWithRoleStore.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/IOpenIDConnectConfigurationWithRoleStore.cs
@@ -10,7 +10,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
 
     public interface IOpenIDConnectConfigurationWithRoleStore : IOpenIDConnectConfigurationStore
     {
-        string GetRoleClaimType();
-        void SetRoleClaimType(string roleClaimType);
+        string? GetRoleClaimType();
+        void SetRoleClaimType(string? roleClaimType);
     }
 }

--- a/source/Server.OpenIDConnect.Common/Configuration/IOpenIDConnectWithClientSecretConfigurationStore.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/IOpenIDConnectWithClientSecretConfigurationStore.cs
@@ -9,7 +9,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
 
     public interface IOpenIDConnectWithClientSecretConfigurationStore : IOpenIDConnectConfigurationStore
     {
-        SensitiveString GetClientSecret();
-        void SetClientSecret(SensitiveString clientSecret);
+        SensitiveString? GetClientSecret();
+        void SetClientSecret(SensitiveString? clientSecret);
     }
 }

--- a/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfiguration.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfiguration.cs
@@ -23,13 +23,13 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
             AllowAutoUserCreation = true;
         }
 
-        public string Issuer { get; set; }
+        public string? Issuer { get; set; }
 
-        public string ClientId { get; set; }
+        public string? ClientId { get; set; }
 
-        public string Scope { get; set; }
+        public string? Scope { get; set; }
 
-        public string NameClaimType { get; set; }
+        public string? NameClaimType { get; set; }
 
         public bool AllowAutoUserCreation { get; set; }
     }

--- a/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfigurationResource.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfigurationResource.cs
@@ -8,12 +8,12 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
     {
         [Description("Follow our documentation to find the Issuer for your identity provider")]
         [Writeable]
-        public virtual string Issuer { get; set; }
+        public virtual string? Issuer { get; set; }
 
         [DisplayName("Client ID")]
         [Description("Octopus instances unique authentication id, as provided by your Octopus account")]
         [Writeable]
-        public virtual string ClientId { get; set; }
+        public virtual string? ClientId { get; set; }
 
         [DisplayName("Allow Auto User Creation")]
         [Description("Tell Octopus to automatically create a user account when a person signs in for the first time with this identity provider")]

--- a/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfigurationStore.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfigurationStore.cs
@@ -15,12 +15,12 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
         {
         }
 
-        public string GetIssuer()
+        public string? GetIssuer()
         {
             return GetProperty(doc => doc.Issuer);
         }
 
-        public void SetIssuer(string issuer)
+        public void SetIssuer(string? issuer)
         {
             Guid issuerAsGuid;
             if (Guid.TryParse(issuer, out issuerAsGuid))
@@ -30,32 +30,32 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
             SetProperty(doc => doc.Issuer = issuer);
         }
 
-        public string GetClientId()
+        public string? GetClientId()
         {
             return GetProperty(doc => doc.ClientId);
         }
 
-        public void SetClientId(string clientId)
+        public void SetClientId(string? clientId)
         {
             SetProperty(doc => doc.ClientId = clientId);
         }
 
-        public string GetScope()
+        public string? GetScope()
         {
             return GetProperty(doc => doc.Scope);
         }
 
-        public void SetScope(string scope)
+        public void SetScope(string? scope)
         {
             SetProperty(doc => doc.Scope = scope);
         }
 
-        public string GetNameClaimType()
+        public string? GetNameClaimType()
         {
             return GetProperty(doc => doc.NameClaimType);
         }
 
-        public void SetNameClaimType(string nameClaimType)
+        public void SetNameClaimType(string? nameClaimType)
         {
             SetProperty(doc => doc.NameClaimType = nameClaimType);
         }

--- a/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfigurationWithClientSecret.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfigurationWithClientSecret.cs
@@ -12,6 +12,6 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
         {
         }
 
-        public SensitiveString ClientSecret { get; set; }
+        public SensitiveString? ClientSecret { get; set; }
     }
 }

--- a/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfigurationWithClientSecretResource.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfigurationWithClientSecretResource.cs
@@ -9,6 +9,6 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
         [DisplayName("Client Secret")]
         [Description("Shared secret for validating the authentication tokens")]
         [Writeable]
-        public virtual SensitiveValue ClientSecret { get; set; }
+        public virtual SensitiveValue? ClientSecret { get; set; }
     }
 }

--- a/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfigurationWithRole.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfigurationWithRole.cs
@@ -10,6 +10,6 @@
         {
         }
 
-        public string RoleClaimType { get; set; }
+        public string? RoleClaimType { get; set; }
     }
 }

--- a/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfigurationWithRoleStore.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectConfigurationWithRoleStore.cs
@@ -10,12 +10,12 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
         {
         }
 
-        public string GetRoleClaimType()
+        public string? GetRoleClaimType()
         {
             return GetProperty(doc => doc.RoleClaimType);
         }
 
-        public void SetRoleClaimType(string roleClaimType)
+        public void SetRoleClaimType(string? roleClaimType)
         {
             SetProperty(doc => doc.RoleClaimType = roleClaimType);
         }

--- a/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectWithClientSecretConfigurationStore.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/OpenIDConnectWithClientSecretConfigurationStore.cs
@@ -10,12 +10,12 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
         {
         }
 
-        public SensitiveString GetClientSecret()
+        public SensitiveString? GetClientSecret()
         {
             return GetProperty(doc => doc.ClientSecret);
         }
 
-        public void SetClientSecret(SensitiveString clientSecret)
+        public void SetClientSecret(SensitiveString? clientSecret)
         {
             SetProperty(doc => doc.ClientSecret = clientSecret);
         }

--- a/source/Server.OpenIDConnect.Common/Configuration/OpenIdConnectConfigurationSettings.cs
+++ b/source/Server.OpenIDConnect.Common/Configuration/OpenIdConnectConfigurationSettings.cs
@@ -22,11 +22,11 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Confi
             var isEnabled = ConfigurationDocumentStore.GetIsEnabled();
 
             yield return new ConfigurationValue<bool>($"Octopus.{configurationSettingsName}.IsEnabled", isEnabled, isEnabled, "Is Enabled");
-            yield return new ConfigurationValue<string>($"Octopus.{configurationSettingsName}.Issuer", ConfigurationDocumentStore.GetIssuer(), isEnabled, "Issuer");
-            yield return new ConfigurationValue<string>($"Octopus.{configurationSettingsName}.ClientId", ConfigurationDocumentStore.GetClientId(), isEnabled, "ClientId");
-            yield return new ConfigurationValue<string>($"Octopus.{configurationSettingsName}.Scope", ConfigurationDocumentStore.GetScope(), isEnabled && ConfigurationDocumentStore.GetScope() != OpenIDConnectConfiguration.DefaultScope, "Scope");
-            yield return new ConfigurationValue<string>($"Octopus.{configurationSettingsName}.RedirectUri", ConfigurationDocumentStore.RedirectUri, isEnabled, "RedirectUri");
-            yield return new ConfigurationValue<string>($"Octopus.{configurationSettingsName}.NameClaimType", ConfigurationDocumentStore.GetNameClaimType(), isEnabled && ConfigurationDocumentStore.GetNameClaimType() != OpenIDConnectConfiguration.DefaultNameClaimType, "Name Claim Type");
+            yield return new ConfigurationValue<string?>($"Octopus.{configurationSettingsName}.Issuer", ConfigurationDocumentStore.GetIssuer(), isEnabled, "Issuer");
+            yield return new ConfigurationValue<string?>($"Octopus.{configurationSettingsName}.ClientId", ConfigurationDocumentStore.GetClientId(), isEnabled, "ClientId");
+            yield return new ConfigurationValue<string?>($"Octopus.{configurationSettingsName}.Scope", ConfigurationDocumentStore.GetScope(), isEnabled && ConfigurationDocumentStore.GetScope() != OpenIDConnectConfiguration.DefaultScope, "Scope");
+            yield return new ConfigurationValue<string?>($"Octopus.{configurationSettingsName}.RedirectUri", ConfigurationDocumentStore.RedirectUri, isEnabled, "RedirectUri");
+            yield return new ConfigurationValue<string?>($"Octopus.{configurationSettingsName}.NameClaimType", ConfigurationDocumentStore.GetNameClaimType(), isEnabled && ConfigurationDocumentStore.GetNameClaimType() != OpenIDConnectConfiguration.DefaultNameClaimType, "Name Claim Type");
             yield return new ConfigurationValue<bool>($"Octopus.{configurationSettingsName}.AllowAutoUserCreation", ConfigurationDocumentStore.GetAllowAutoUserCreation(), isEnabled, "Allow auto user creation");
         }
 

--- a/source/Server.OpenIDConnect.Common/Identities/IIdentityCreator.cs
+++ b/source/Server.OpenIDConnect.Common/Identities/IIdentityCreator.cs
@@ -4,6 +4,6 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Ident
 {
     public interface IIdentityCreator
     {
-        Identity Create(string email, string displayName, string externalId);
+        Identity Create(string? email, string? displayName, string? externalId);
     }
 }

--- a/source/Server.OpenIDConnect.Common/Identities/IdentityCreator.cs
+++ b/source/Server.OpenIDConnect.Common/Identities/IdentityCreator.cs
@@ -9,12 +9,17 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Ident
 
         protected abstract string ProviderName { get; }
 
-        public Identity Create(string email, string displayName, string externalId)
+        public Identity Create(string? email, string? displayName, string? externalId)
         {
-            return new Identity(ProviderName)
-                .WithClaim(ClaimDescriptor.EmailClaimType, email, true)
-                .WithClaim(ClaimDescriptor.DisplayNameClaimType, displayName, false)
-                .WithClaim(ExternalIdClaimType, externalId, true, true);
+            var identity = new Identity(ProviderName);
+            if (email != null)
+                identity = identity.WithClaim(ClaimDescriptor.EmailClaimType, email, true);
+            if (displayName != null)
+                identity = identity.WithClaim(ClaimDescriptor.DisplayNameClaimType, displayName, false);
+            if (externalId != null)
+                identity = identity.WithClaim(ExternalIdClaimType, externalId, true, true);
+
+            return identity;
         }
     }
 }

--- a/source/Server.OpenIDConnect.Common/Infrastructure/PrincipalToUserResourceMapper.cs
+++ b/source/Server.OpenIDConnect.Common/Infrastructure/PrincipalToUserResourceMapper.cs
@@ -25,17 +25,17 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Infra
             return userResource;
         }
 
-        protected virtual string GetExternalId(ClaimsPrincipal principal)
+        protected virtual string? GetExternalId(ClaimsPrincipal principal)
         {
             return GetClaimValue(principal, ClaimTypes.NameIdentifier);
         }
 
-        protected virtual string GetUsername(ClaimsPrincipal principal)
+        protected virtual string? GetUsername(ClaimsPrincipal principal)
         {
             return GetClaimValue(principal, ClaimTypes.Email) ?? GetClaimValue(principal, ClaimTypes.NameIdentifier);
         }
 
-        protected virtual string GetEmailAddress(ClaimsPrincipal principal)
+        protected virtual string? GetEmailAddress(ClaimsPrincipal principal)
         {
             return GetClaimValue(principal, ClaimTypes.Email);
         }
@@ -45,7 +45,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Infra
             return principal.Identity.Name;
         }
 
-        protected string GetClaimValue(ClaimsPrincipal principal, string type)
+        protected string? GetClaimValue(ClaimsPrincipal principal, string type)
         {
             // NOTE: The System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler maps OIDC claims from short to long names.
             // See System.IdentityModel.Tokens.Jwt.ClaimTypeMapping for more details.

--- a/source/Server.OpenIDConnect.Common/Infrastructure/State.cs
+++ b/source/Server.OpenIDConnect.Common/Infrastructure/State.cs
@@ -6,33 +6,13 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Infra
 {
     public static class State
     {
-        public static string Generate(string postLoginRedirectTo)
-        {
-            var state = "~/app";
-            if (!string.IsNullOrWhiteSpace(postLoginRedirectTo))
-                state = postLoginRedirectTo;
-            return state;
-        }
-
-        public static string Protect(string state)
+        public static string Protect(string? state)
         {
             using (var sha = SHA256.Create())
             {
                 var stateHash = Convert.ToBase64String(sha.ComputeHash(Encoding.UTF8.GetBytes("OctoState" + state)));
                 return stateHash;
             }
-        }
-
-        public static string Encode(string plainText)
-        {
-            var plainTextBytes = Encoding.UTF8.GetBytes(plainText);
-            return Convert.ToBase64String(plainTextBytes);
-        }
-
-        public static string Decode(string encodedState)
-        {
-            var encodedBytes = Convert.FromBase64String(encodedState);
-            return Encoding.UTF8.GetString(encodedBytes);
         }
     }
 }

--- a/source/Server.OpenIDConnect.Common/Infrastructure/UserResource.cs
+++ b/source/Server.OpenIDConnect.Common/Infrastructure/UserResource.cs
@@ -2,9 +2,9 @@
 {
     public class UserResource
     {
-        public string Username { get; set; }
-        public string DisplayName { get; set; }
-        public string EmailAddress { get; set; }
-        public string ExternalId { get; set; }
+        public string? Username { get; set; }
+        public string? DisplayName { get; set; }
+        public string? EmailAddress { get; set; }
+        public string? ExternalId { get; set; }
     }
 }

--- a/source/Server.OpenIDConnect.Common/Issuer/AuthorizationEndpointUrlBuilder.cs
+++ b/source/Server.OpenIDConnect.Common/Issuer/AuthorizationEndpointUrlBuilder.cs
@@ -19,7 +19,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Issue
         protected virtual string ResponseType => OpenIDConnectConfiguration.DefaultResponseType;
         protected virtual string ResponseMode => OpenIDConnectConfiguration.DefaultResponseMode;
 
-        public virtual string Build(string requestDirectoryPath, IssuerConfiguration issuerConfiguration, string nonce, string state = null)
+        public virtual string Build(string requestDirectoryPath, IssuerConfiguration issuerConfiguration, string nonce, string? state = null)
         {
             if (issuerConfiguration == null)
                 throw new ArgumentException("issuerConfiguration is required", nameof(issuerConfiguration));

--- a/source/Server.OpenIDConnect.Common/Issuer/IAuthorizationEndpointUrlBuilder.cs
+++ b/source/Server.OpenIDConnect.Common/Issuer/IAuthorizationEndpointUrlBuilder.cs
@@ -2,6 +2,6 @@
 {
     public interface IAuthorizationEndpointUrlBuilder
     {
-        string Build(string requestDirectoryPath, IssuerConfiguration issuerConfiguration, string nonce, string state = null);
+        string Build(string requestDirectoryPath, IssuerConfiguration issuerConfiguration, string nonce, string? state = null);
     }
 }

--- a/source/Server.OpenIDConnect.Common/Issuer/IssuerConfiguration.cs
+++ b/source/Server.OpenIDConnect.Common/Issuer/IssuerConfiguration.cs
@@ -4,12 +4,12 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Issue
 {
     public class IssuerConfiguration
     {
-        public string Issuer  { get; set; }
+        public string Issuer  { get; set; } = string.Empty;
 
         [JsonProperty("jwks_uri")]
-        public string JwksUri { get; set; }
+        public string JwksUri { get; set; } = string.Empty;
         
         [JsonProperty("authorization_endpoint")]
-        public string AuthorizationEndpoint { get; set; }
+        public string AuthorizationEndpoint { get; set; } = string.Empty;
     }
 }

--- a/source/Server.OpenIDConnect.Common/Server.OpenIDConnect.Common.csproj
+++ b/source/Server.OpenIDConnect.Common/Server.OpenIDConnect.Common.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0001" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1-ci0001" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1" />
     <PackageReference Include="Octopus.Time" Version="1.1.5" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.3" />
   </ItemGroup>

--- a/source/Server.OpenIDConnect.Common/Server.OpenIDConnect.Common.csproj
+++ b/source/Server.OpenIDConnect.Common/Server.OpenIDConnect.Common.csproj
@@ -1,21 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common</AssemblyName>
     <Description>Common components for the Octopus OpenID Connect authentication providers.</Description>
     <Authors>Octopus Deploy</Authors>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
-    <PackageLicenseUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders</PackageProjectUrl>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-    <PackageReference Include="Octopus.Data" Version="5.0.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.0" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.0" />
+    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0008" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0008" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0007" />
     <PackageReference Include="Octopus.Time" Version="1.1.5" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.3" />
   </ItemGroup>

--- a/source/Server.OpenIDConnect.Common/Server.OpenIDConnect.Common.csproj
+++ b/source/Server.OpenIDConnect.Common/Server.OpenIDConnect.Common.csproj
@@ -8,15 +8,15 @@
     <Authors>Octopus Deploy</Authors>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders</PackageProjectUrl>    
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0013" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0008" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0010" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0001" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1-ci0001" />
     <PackageReference Include="Octopus.Time" Version="1.1.5" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.3" />
   </ItemGroup>

--- a/source/Server.OpenIDConnect.Common/Server.OpenIDConnect.Common.csproj
+++ b/source/Server.OpenIDConnect.Common/Server.OpenIDConnect.Common.csproj
@@ -13,10 +13,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0008" />
+    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0013" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0008" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0007" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0010" />
     <PackageReference Include="Octopus.Time" Version="1.1.5" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.3" />
   </ItemGroup>

--- a/source/Server.OpenIDConnect.Common/Tokens/ClaimsPrincipleContainer.cs
+++ b/source/Server.OpenIDConnect.Common/Tokens/ClaimsPrincipleContainer.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Claims;
+﻿using System;
+using System.Security.Claims;
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Tokens
 {
@@ -7,6 +8,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Token
         public ClaimsPrincipleContainer(string error)
         {
             this.Error = error;
+            ExternalGroupIds = Array.Empty<string>();
         }
         public ClaimsPrincipleContainer(ClaimsPrincipal principal, string[] externalGroupIds)
         {
@@ -14,12 +16,12 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Token
             ExternalGroupIds = externalGroupIds;
         }
 
-        public string Error { get; private set; }
-        public ClaimsPrincipal Principal { get; private set; }
+        public string? Error { get; }
+        public ClaimsPrincipal? Principal { get; }
 
         /// <summary>
         /// Gets or sets the external Role/Group Ids
         /// </summary>
-        public string[] ExternalGroupIds { get; private set; }
+        public string[] ExternalGroupIds { get; }
     }
 }

--- a/source/Server.OpenIDConnect.Common/Tokens/IAuthTokenHandler.cs
+++ b/source/Server.OpenIDConnect.Common/Tokens/IAuthTokenHandler.cs
@@ -5,6 +5,6 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Token
 {
     public interface IAuthTokenHandler
     {
-        Task<ClaimsPrincipleContainer> GetPrincipalAsync(IDictionary<string, string> requestForm, out string stateString);
+        Task<ClaimsPrincipleContainer> GetPrincipalAsync(IDictionary<string, string?> requestForm, out string? stateString);
     }
 }

--- a/source/Server.OpenIDConnect.Common/Tokens/OpenIDConnectAuthTokenHandler.cs
+++ b/source/Server.OpenIDConnect.Common/Tokens/OpenIDConnectAuthTokenHandler.cs
@@ -20,24 +20,24 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Token
         {
         }
 
-        public Task<ClaimsPrincipleContainer> GetPrincipalAsync(IDictionary<string, string> requestForm, out string stateString)
+        public Task<ClaimsPrincipleContainer> GetPrincipalAsync(IDictionary<string, string?> requestForm, out string? stateString)
         {
             stateString = null;
             
             if (requestForm.ContainsKey("error"))
             {
-                var errorDescription = requestForm["error_description"];
+                var errorDescription = requestForm["error_description"] ?? string.Empty;
                 Log.Error($"Failed to authenticate user: {errorDescription}");
                 return Task.FromResult(new ClaimsPrincipleContainer(errorDescription));
             }
 
-            string accessToken = null;
+            string? accessToken = null;
             if (requestForm.ContainsKey("access_token"))
             {
                 accessToken = requestForm["access_token"];
             }
             
-            string idToken = null;
+            string? idToken = null;
             if (requestForm.ContainsKey("id_token"))
             {
                 idToken = requestForm["id_token"];

--- a/source/Server.OpenIDConnect.Common/Web/LoginRedirectLinkRequestModel.cs
+++ b/source/Server.OpenIDConnect.Common/Web/LoginRedirectLinkRequestModel.cs
@@ -4,7 +4,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
 {
     public class LoginRedirectLinkRequestModel
     {
-        public string ApiAbsUrl { get; set; }
-        public LoginState State { get; set; }
+        public string ApiAbsUrl { get; set; } = string.Empty;
+        public LoginState State { get; set; } = new LoginState();
     }
 }

--- a/source/Server.OpenIDConnect.Common/Web/LoginRedirectLinkResponseModel.cs
+++ b/source/Server.OpenIDConnect.Common/Web/LoginRedirectLinkResponseModel.cs
@@ -2,6 +2,6 @@
 {
     public class LoginRedirectLinkResponseModel
     {
-        public string ExternalAuthenticationUrl { get; set; }
+        public string ExternalAuthenticationUrl { get; set; } = string.Empty;
     }
 }

--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedAction.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Octopus.Data;
 using Octopus.Data.Model.User;
 using Octopus.Data.Storage.User;
 using Octopus.Diagnostics;
@@ -40,16 +41,16 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
         protected readonly TStore ConfigurationStore;
 
         protected UserAuthenticatedAction(
-            ILog log, 
-            TAuthTokenHandler authTokenHandler, 
-            IPrincipalToUserResourceMapper principalToUserResourceMapper, 
-            IUpdateableUserStore userStore, 
-            TStore configurationStore, 
-            IAuthCookieCreator authCookieCreator, 
-            IInvalidLoginTracker loginTracker, 
-            ISleep sleep, 
-            TIdentityCreator identityCreator, 
-            IClock clock, 
+            ILog log,
+            TAuthTokenHandler authTokenHandler,
+            IPrincipalToUserResourceMapper principalToUserResourceMapper,
+            IUpdateableUserStore userStore,
+            TStore configurationStore,
+            IAuthCookieCreator authCookieCreator,
+            IInvalidLoginTracker loginTracker,
+            ISleep sleep,
+            TIdentityCreator identityCreator,
+            IClock clock,
             IUrlEncoder encoder)
         {
             this.log = log;
@@ -77,7 +78,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
                 BadRequest(context, $"The response from the external identity provider contained an error: {principalContainer.Error}");
                 return;
             }
-            
+
             // Step 2: Validate the state object we passed wasn't tampered with
             const string stateDescription = "As a security precaution, Octopus ensures the state object returned from the external identity provider matches what it expected.";
             var expectedStateHash = string.Empty;
@@ -145,27 +146,27 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
             {
                 // Step 4b: Try to get or create a the Octopus User this external identity represents
                 var userResult = GetOrCreateUser(authenticationCandidate, principalContainer.ExternalGroupIds, cts.Token);
-                if (userResult.WasSuccessful)
+                if (userResult is ISuccessResult<IUser> successResult)
                 {
                     loginTracker.RecordSucess(authenticationCandidate.Username, context.Request.Host);
 
-                    var authCookies = authCookieCreator.CreateAuthCookies(userResult.Value.IdentificationToken, SessionExpiry.TwentyDays, context.Request.IsHttps, stateFromRequest.UsingSecureConnection);
+                    var authCookies = authCookieCreator.CreateAuthCookies(successResult.Value.IdentificationToken, SessionExpiry.TwentyDays, context.Request.IsHttps, stateFromRequest.UsingSecureConnection);
 
                     foreach (var cookie in authCookies)
                     {
                         context.Response.WithCookie(cookie);
                     }
 
-                    if (!userResult.Value.IsActive)
+                    if (!successResult.Value.IsActive)
                     {
-                        BadRequest(context, 
+                        BadRequest(context,
                             $"The Octopus User Account '{authenticationCandidate.Username}' has been disabled by an Administrator. If you believe this to be a mistake, please contact your Octopus Administrator to have your account re-enabled.");
                         return;
                     }
 
-                    if (userResult.Value.IsService)
+                    if (successResult.Value.IsService)
                     {
-                        BadRequest(context, 
+                        BadRequest(context,
                             $"The Octopus User Account '{authenticationCandidate.Username}' is a Service Account, which are prevented from using Octopus interactively. Service Accounts are designed to authorize external systems to access the Octopus API using an API Key.");
                         return;
                     }
@@ -186,7 +187,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
                     sleep.For(1000);
                 }
 
-                BadRequest(context, $"User login failed: {userResult.ErrorString}");
+                BadRequest(context, $"User login failed: {((FailureResult)userResult).ErrorString}");
             }
         }
 
@@ -196,7 +197,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
             context.Response.BadRequest(message);
         }
 
-        ResultFromExtension<IUser> GetOrCreateUser(UserResource userResource, string[] groups, CancellationToken cancellationToken)
+        IResultFromExtension<IUser> GetOrCreateUser(UserResource userResource, string[] groups, CancellationToken cancellationToken)
         {
             var identityToMatch = NewIdentity(userResource);
 
@@ -228,14 +229,15 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
                 return ResultFromExtension<IUser>.Failed("User could not be located and auto user creation is not enabled.");
 
             var userResult = userStore.Create(
-                userResource.Username ?? string.Empty, 
-                userResource.DisplayName ?? string.Empty, 
+                userResource.Username ?? string.Empty,
+                userResource.DisplayName ?? string.Empty,
                 userResource.EmailAddress ?? string.Empty,
                 cancellationToken,
                 new ProviderUserGroups { IdentityProviderName = ProviderName, GroupIds = groups },
                 new[] { identityToMatch });
-
-            return ResultFromExtension<IUser>.Success(userResult.Value);
+            if (userResult is FailureResult failureResult)
+                return ResultFromExtension<IUser>.Failed(failureResult.Errors);
+            return ResultFromExtension<IUser>.Success(((ISuccessResult<IUser>)userResult).Value);
         }
 
         bool MatchesProviderAndExternalId(UserResource userResource, Identity x)

--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticationAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticationAction.cs
@@ -66,7 +66,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
             // Finally, provide the client with the information it requires to initiate the redirect to the external identity provider
             try
             {
-                var issuer = ConfigurationStore.GetIssuer();
+                var issuer = ConfigurationStore.GetIssuer() ?? string.Empty;
                 var issuerConfig = await identityProviderConfigDiscoverer.GetConfigurationAsync(issuer);
 
                 // Use a non-deterministic nonce to prevent replay attacks

--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticationAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticationAction.cs
@@ -77,8 +77,8 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
 
                 // These cookies are used to validate the data returned from the external identity provider - this prevents tampering
                 context.Response.AsOctopusJson(new LoginRedirectLinkResponseModel {ExternalAuthenticationUrl = url})
-                    .WithCookie(new OctoCookie {Name = UserAuthConstants.OctopusStateCookieName, Value = State.Protect(stateString), HttpOnly = true, Secure = state.UsingSecureConnection, Expires = DateTimeOffset.UtcNow.AddMinutes(20)})
-                    .WithCookie(new OctoCookie {Name = UserAuthConstants.OctopusNonceCookieName, Value = Nonce.Protect(nonce), HttpOnly = true, Secure = state.UsingSecureConnection, Expires = DateTimeOffset.UtcNow.AddMinutes(20)});
+                    .WithCookie(new OctoCookie(UserAuthConstants.OctopusStateCookieName, State.Protect(stateString)) { HttpOnly = true, Secure = state.UsingSecureConnection, Expires = DateTimeOffset.UtcNow.AddMinutes(20) })
+                    .WithCookie(new OctoCookie(UserAuthConstants.OctopusNonceCookieName, Nonce.Protect(nonce)) { HttpOnly = true, Secure = state.UsingSecureConnection, Expires = DateTimeOffset.UtcNow.AddMinutes(20) });
             }
             catch (ArgumentException ex)
             {


### PR DESCRIPTION
Changing the method return types to align with the new nullable patterns we've set up in ServerExtensibility and AuthenticationExtensibility.

Depends on:
OctopusDeploy/AuthenticationExtensibility#15