### PR TITLE
Add support for cookie same site policy

### DIFF
--- a/source/Server.OpenIDConnect.Common/Server.OpenIDConnect.Common.csproj
+++ b/source/Server.OpenIDConnect.Common/Server.OpenIDConnect.Common.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="Octopus.Data" Version="5.2.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="11.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="11.2.0-mattr-samesiteno0016" />
     <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1" />
     <PackageReference Include="Octopus.Time" Version="1.1.5" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.3" />

--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedAction.cs
@@ -157,8 +157,8 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
 
                     var octoResponse = Redirect.Response(stateFromRequest.RedirectAfterLoginTo)
                         .WithHeader("Expires", new[] {DateTime.UtcNow.AddYears(1).ToString("R", DateTimeFormatInfo.InvariantInfo)})
-                        .WithCookie(new OctoCookie(UserAuthConstants.OctopusStateCookieName, Guid.NewGuid().ToString()) {HttpOnly = true, Secure = false, Expires = DateTimeOffset.MinValue})
-                        .WithCookie(new OctoCookie(UserAuthConstants.OctopusNonceCookieName, Guid.NewGuid().ToString()) {HttpOnly = true, Secure = false, Expires = DateTimeOffset.MinValue});
+                        .WithCookie(new OctoCookie(UserAuthConstants.OctopusStateCookieName, Guid.NewGuid().ToString()) {HttpOnly = true, Secure = false, Expires = DateTimeOffset.MinValue, SameSite = SameSiteMode.None})
+                        .WithCookie(new OctoCookie(UserAuthConstants.OctopusNonceCookieName, Guid.NewGuid().ToString()) {HttpOnly = true, Secure = false, Expires = DateTimeOffset.MinValue, SameSite = SameSiteMode.None});
 
                     var authCookies = authCookieCreator.CreateAuthCookies(successResult.Value.IdentificationToken, SessionExpiry.TwentyDays, request.IsHttps, stateFromRequest.UsingSecureConnection);
 

--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticationAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticationAction.cs
@@ -18,7 +18,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
         static readonly BadRequestRegistration PotentialOpenDirect = new BadRequestRegistration("Request not allowed, due to potential Open Redirection attack");
         static readonly BadRequestRegistration LoginFailed = new BadRequestRegistration("Login failed. Please see the Octopus Server logs for more details.");
         static readonly OctopusJsonRegistration<LoginRedirectLinkResponseModel> Result = new OctopusJsonRegistration<LoginRedirectLinkResponseModel>();
-        
+
         readonly ILog log;
         readonly IIdentityProviderConfigDiscoverer identityProviderConfigDiscoverer;
         readonly IAuthorizationEndpointUrlBuilder urlBuilder;
@@ -80,8 +80,8 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
 
                 // These cookies are used to validate the data returned from the external identity provider - this prevents tampering
                 return Result.Response(new LoginRedirectLinkResponseModel {ExternalAuthenticationUrl = url})
-                    .WithCookie(new OctoCookie(UserAuthConstants.OctopusStateCookieName, State.Protect(stateString)) { HttpOnly = true, Secure = state.UsingSecureConnection, Expires = DateTimeOffset.UtcNow.AddMinutes(20) })
-                    .WithCookie(new OctoCookie(UserAuthConstants.OctopusNonceCookieName, Nonce.Protect(nonce)) { HttpOnly = true, Secure = state.UsingSecureConnection, Expires = DateTimeOffset.UtcNow.AddMinutes(20) });
+                    .WithCookie(new OctoCookie(UserAuthConstants.OctopusStateCookieName, State.Protect(stateString)) { HttpOnly = true, Secure = state.UsingSecureConnection, Expires = DateTimeOffset.UtcNow.AddMinutes(20), SameSite = SameSiteMode.None })
+                    .WithCookie(new OctoCookie(UserAuthConstants.OctopusNonceCookieName, Nonce.Protect(nonce)) { HttpOnly = true, Secure = state.UsingSecureConnection, Expires = DateTimeOffset.UtcNow.AddMinutes(20), SameSite = SameSiteMode.None });
             }
             catch (ArgumentException ex)
             {


### PR DESCRIPTION
Part of OctopusDeploy/OctopusDeploy#7384

Set the nonce and state cookies to SameSite=None
As they need to be third party cookies so they can be sent to POSTed back to the API.