### PR TITLE
If a user can't be found by identity, fall back to checking Email

### DIFF
--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedAction.cs
@@ -198,6 +198,13 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
                 throw new Exception("There are multiple users with this identity. OpenID Connect identity providers do not support users with duplicate email addresses. Please remove any duplicate users, or make the email addresses unique.");
             var user = matchingUsers.SingleOrDefault();
 
+            if (user == null)
+            {
+                var emailAddress = identityToMatch.Claims[ClaimDescriptor.EmailClaimType].Value;
+                if (!string.IsNullOrWhiteSpace(emailAddress))
+                    user = userStore.GetByEmailAddress(emailAddress).FirstOrDefault();
+            }
+
             if (user != null)
             {
                 userStore.SetSecurityGroupIds(ProviderName, user.Id, groups, clock.GetUtcTime());


### PR DESCRIPTION
At the moment server will fallback to comparing the email from the token to existing usernames within Octopus. This doesn't however work in Octopus instances that have been running against other providers and have usernames already created that don't match the email addresses.

User Email addresses may have changed for a number of reasons over time, but the username in Octopus is immutable, which causes the Authenticated action handlers in this provider to create new users when it shouldn't, because it can't find the existing users.

This has shown in a customer scenario for Okta specifically, but all of the providers would be susceptible to this so the fix has been applied at the common level. The fix is to explicitly fall back to looking for users by Email if the standard `GetByIdentity` doesn't return a user (that call actually has some "fuzzy" matching and fallbacks, but they don't cover this scenario and can't be changed because they would break certain OnPrem AD scenarios).