### PR TITLE
Adding the username as an identifier in Okta

### DIFF
--- a/source/Server.AzureAD/Server.AzureAD.csproj
+++ b/source/Server.AzureAD/Server.AzureAD.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
+    <PackageReference Include="Octopus.Diagnostics" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server.OctopusID/Server.OctopusID.csproj
+++ b/source/Server.OctopusID/Server.OctopusID.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
+    <PackageReference Include="Octopus.Diagnostics" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server.Okta/Configuration/OktaConfiguration.cs
+++ b/source/Server.Okta/Configuration/OktaConfiguration.cs
@@ -11,7 +11,7 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Configuration
         {
             RoleClaimType = DefaultRoleClaimType;
             UsernameClaimType = DefaultUsernameClaimType;
-            Scope = DefaultScope + "%20profile%20groups";
+            Scope = DefaultScope + "%20groups";
         }
 
         public string UsernameClaimType { get; set; }

--- a/source/Server.Okta/Configuration/OktaConfiguration.cs
+++ b/source/Server.Okta/Configuration/OktaConfiguration.cs
@@ -11,7 +11,7 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Configuration
         {
             RoleClaimType = DefaultRoleClaimType;
             UsernameClaimType = DefaultUsernameClaimType;
-            Scope = DefaultScope + "%20groups";
+            Scope = DefaultScope + "%20profile%20groups";
         }
 
         public string UsernameClaimType { get; set; }

--- a/source/Server.Okta/Identities/OktaIdentityCreator.cs
+++ b/source/Server.Okta/Identities/OktaIdentityCreator.cs
@@ -15,7 +15,7 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Identities
         {
             var identity = base.Create(userResource);
             if (userResource.Username != null && userResource.Username != userResource.EmailAddress && userResource.Username != userResource.ExternalId)
-                identity = identity.WithClaim(PreferredUsername, userResource.Username, true, true);
+                identity = identity.WithClaim(PreferredUsername, userResource.Username, true);
 
             return identity;
         }

--- a/source/Server.Okta/Identities/OktaIdentityCreator.cs
+++ b/source/Server.Okta/Identities/OktaIdentityCreator.cs
@@ -2,7 +2,6 @@
 using Octopus.Server.Extensibility.Authentication.Model;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Identities;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Infrastructure;
-using Octopus.Server.Extensibility.Authentication.Resources.Identities;
 
 namespace Octopus.Server.Extensibility.Authentication.Okta.Identities
 {
@@ -15,7 +14,7 @@ namespace Octopus.Server.Extensibility.Authentication.Okta.Identities
         public override Identity Create(UserResource userResource)
         {
             var identity = base.Create(userResource);
-            if (userResource?.Username != null && userResource.Username != userResource.EmailAddress && userResource.Username != userResource.ExternalId)
+            if (userResource.Username != null && userResource.Username != userResource.EmailAddress && userResource.Username != userResource.ExternalId)
                 identity = identity.WithClaim(PreferredUsername, userResource.Username, true, true);
 
             return identity;

--- a/source/Server.Okta/Identities/OktaIdentityCreator.cs
+++ b/source/Server.Okta/Identities/OktaIdentityCreator.cs
@@ -1,10 +1,25 @@
-﻿using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Identities;
+﻿using Octopus.Data.Model.User;
+using Octopus.Server.Extensibility.Authentication.Model;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Identities;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Infrastructure;
+using Octopus.Server.Extensibility.Authentication.Resources.Identities;
 
 namespace Octopus.Server.Extensibility.Authentication.Okta.Identities
 {
     class OktaIdentityCreator : IdentityCreator, IOktaIdentityCreator
     {
+        public const string PreferredUsername = "pun";
+        
         protected override string ProviderName => OktaAuthenticationProvider.ProviderName;
+
+        public override Identity Create(UserResource userResource)
+        {
+            var identity = base.Create(userResource);
+            if (userResource?.Username != null && userResource.Username != userResource.EmailAddress && userResource.Username != userResource.ExternalId)
+                identity = identity.WithClaim(PreferredUsername, userResource.Username, true, true);
+
+            return identity;
+        }
     }
 
     interface IOktaIdentityCreator : IIdentityCreator

--- a/source/Server.Okta/Server.Okta.csproj
+++ b/source/Server.Okta/Server.Okta.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
+    <PackageReference Include="Octopus.Diagnostics" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server.OpenIDConnect.Common/Identities/IIdentityCreator.cs
+++ b/source/Server.OpenIDConnect.Common/Identities/IIdentityCreator.cs
@@ -1,9 +1,10 @@
 ﻿using Octopus.Data.Model.User;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Infrastructure;
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Identities
 {
     public interface IIdentityCreator
     {
-        Identity Create(string? email, string? displayName, string? externalId);
+        Identity Create(UserResource userResource);
     }
 }

--- a/source/Server.OpenIDConnect.Common/Identities/IdentityCreator.cs
+++ b/source/Server.OpenIDConnect.Common/Identities/IdentityCreator.cs
@@ -1,5 +1,6 @@
 using Octopus.Data.Model.User;
 using Octopus.Server.Extensibility.Authentication.Model;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Infrastructure;
 using Octopus.Server.Extensibility.Authentication.Resources.Identities;
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Identities
@@ -10,15 +11,15 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Ident
 
         protected abstract string ProviderName { get; }
 
-        public Identity Create(string? email, string? displayName, string? externalId)
+        public virtual Identity Create(UserResource userResource)
         {
             var identity = new Identity(ProviderName);
-            if (email != null)
-                identity = identity.WithClaim(ClaimDescriptor.EmailClaimType, email, true);
-            if (displayName != null)
-                identity = identity.WithClaim(ClaimDescriptor.DisplayNameClaimType, displayName, false);
-            if (externalId != null)
-                identity = identity.WithClaim(ExternalIdClaimType, externalId, true, true);
+            if (userResource?.EmailAddress != null)
+                identity = identity.WithClaim(ClaimDescriptor.EmailClaimType, userResource.EmailAddress, true);
+            if (userResource?.DisplayName != null)
+                identity = identity.WithClaim(ClaimDescriptor.DisplayNameClaimType, userResource.DisplayName, false);
+            if (userResource?.ExternalId != null)
+                identity = identity.WithClaim(ExternalIdClaimType, userResource.ExternalId, true, true);
 
             return identity;
         }

--- a/source/Server.OpenIDConnect.Common/Identities/IdentityCreator.cs
+++ b/source/Server.OpenIDConnect.Common/Identities/IdentityCreator.cs
@@ -14,11 +14,11 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Ident
         public virtual Identity Create(UserResource userResource)
         {
             var identity = new Identity(ProviderName);
-            if (userResource?.EmailAddress != null)
+            if (userResource.EmailAddress != null)
                 identity = identity.WithClaim(ClaimDescriptor.EmailClaimType, userResource.EmailAddress, true);
-            if (userResource?.DisplayName != null)
+            if (userResource.DisplayName != null)
                 identity = identity.WithClaim(ClaimDescriptor.DisplayNameClaimType, userResource.DisplayName, false);
-            if (userResource?.ExternalId != null)
+            if (userResource.ExternalId != null)
                 identity = identity.WithClaim(ExternalIdClaimType, userResource.ExternalId, true, true);
 
             return identity;

--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedAction.cs
@@ -74,7 +74,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
         public async Task<IOctoResponseProvider> ExecuteAsync(IOctoRequest request)
         {
             // Step 1: Try and get all of the details from the request making sure there are no errors passed back from the external identity provider
-            var principalContainer = await authTokenHandler.GetPrincipalAsync(request.Form.ToDictionary(pair => pair.Key, pair => pair.Value), out var stateStringFromRequest);
+            var principalContainer = await authTokenHandler.GetPrincipalAsync(request.Form.ToDictionary(pair => pair.Key, pair => (string?)pair.Value), out var stateStringFromRequest);
             var principal = principalContainer.Principal;
             if (principal == null || !string.IsNullOrEmpty(principalContainer.Error))
             {
@@ -239,10 +239,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
 
         Identity NewIdentity(UserResource userResource)
         {
-            return identityCreator.Create(
-                userResource.EmailAddress,
-                userResource.DisplayName,
-                userResource.ExternalId);
+            return identityCreator.Create(userResource);
         }
     }
 }


### PR DESCRIPTION
When trying to match an Okta user with the same username and email address in both Octopus and Okta, it was failing to find the user when the preferred username was the Okta username (throwing a user exists error when trying to create the user), but would create a new user if the preferred username was the Okta Email field.

This change adds the Okta Preferred Username value as an identifier, if not already in the list of identifiers.  This should allow the user to be found by username (Okta's preferred username), and then verified by Email address.

Before:
When Okta is set up to use referred_username as the Username Claim Type:
![Okta Setup](https://user-images.githubusercontent.com/81208241/122041093-e963c200-ce1b-11eb-8399-404ffe22bd8a.png)

![Login Failed](https://user-images.githubusercontent.com/81208241/122040798-9a1d9180-ce1b-11eb-9fd9-2e825e4e8ecb.png)

After:
![Authenticated](https://user-images.githubusercontent.com/81208241/122040851-abff3480-ce1b-11eb-8b9d-556565e88019.png)
