### PR TITLE
Andrew w/okta preferred username

### DIFF
--- a/source/Server.Okta/Identities/OktaIdentityCreator.cs
+++ b/source/Server.Okta/Identities/OktaIdentityCreator.cs
@@ -1,10 +1,24 @@
-﻿using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Identities;
+﻿using Octopus.Data.Model.User;
+using Octopus.Server.Extensibility.Authentication.Model;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Identities;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Infrastructure;
 
 namespace Octopus.Server.Extensibility.Authentication.Okta.Identities
 {
     class OktaIdentityCreator : IdentityCreator, IOktaIdentityCreator
     {
+        public const string PreferredUsername = "pun";
+        
         protected override string ProviderName => OktaAuthenticationProvider.ProviderName;
+
+        public override Identity Create(UserResource userResource)
+        {
+            var identity = base.Create(userResource);
+            if (userResource.Username != null && userResource.Username != userResource.EmailAddress && userResource.Username != userResource.ExternalId)
+                identity = identity.WithClaim(PreferredUsername, userResource.Username, true);
+
+            return identity;
+        }
     }
 
     interface IOktaIdentityCreator : IIdentityCreator

--- a/source/Server.Okta/Identities/OktaIdentityCreator.cs
+++ b/source/Server.Okta/Identities/OktaIdentityCreator.cs
@@ -1,5 +1,4 @@
 ﻿using Octopus.Data.Model.User;
-using Octopus.Server.Extensibility.Authentication.Model;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Identities;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Infrastructure;
 

--- a/source/Server.OpenIDConnect.Common/Identities/IIdentityCreator.cs
+++ b/source/Server.OpenIDConnect.Common/Identities/IIdentityCreator.cs
@@ -1,9 +1,10 @@
 ﻿using Octopus.Data.Model.User;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Infrastructure;
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Identities
 {
     public interface IIdentityCreator
     {
-        Identity Create(string? email, string? displayName, string? externalId);
+        Identity Create(UserResource userResource);
     }
 }

--- a/source/Server.OpenIDConnect.Common/Identities/IdentityCreator.cs
+++ b/source/Server.OpenIDConnect.Common/Identities/IdentityCreator.cs
@@ -1,5 +1,4 @@
 using Octopus.Data.Model.User;
-using Octopus.Server.Extensibility.Authentication.Model;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Infrastructure;
 using Octopus.Server.Extensibility.Authentication.Resources.Identities;
 

--- a/source/Server.OpenIDConnect.Common/Identities/IdentityCreator.cs
+++ b/source/Server.OpenIDConnect.Common/Identities/IdentityCreator.cs
@@ -1,4 +1,6 @@
 using Octopus.Data.Model.User;
+using Octopus.Server.Extensibility.Authentication.Model;
+using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Infrastructure;
 using Octopus.Server.Extensibility.Authentication.Resources.Identities;
 
 namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Identities
@@ -9,15 +11,15 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Ident
 
         protected abstract string ProviderName { get; }
 
-        public Identity Create(string? email, string? displayName, string? externalId)
+        public virtual Identity Create(UserResource userResource)
         {
             var identity = new Identity(ProviderName);
-            if (email != null)
-                identity = identity.WithClaim(ClaimDescriptor.EmailClaimType, email, true);
-            if (displayName != null)
-                identity = identity.WithClaim(ClaimDescriptor.DisplayNameClaimType, displayName, false);
-            if (externalId != null)
-                identity = identity.WithClaim(ExternalIdClaimType, externalId, true, true);
+            if (userResource.EmailAddress != null)
+                identity = identity.WithClaim(ClaimDescriptor.EmailClaimType, userResource.EmailAddress, true);
+            if (userResource.DisplayName != null)
+                identity = identity.WithClaim(ClaimDescriptor.DisplayNameClaimType, userResource.DisplayName, false);
+            if (userResource.ExternalId != null)
+                identity = identity.WithClaim(ExternalIdClaimType, userResource.ExternalId, true, true);
 
             return identity;
         }

--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedAction.cs
@@ -74,7 +74,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
         public async Task<IOctoResponseProvider> ExecuteAsync(IOctoRequest request)
         {
             // Step 1: Try and get all of the details from the request making sure there are no errors passed back from the external identity provider
-            var principalContainer = await authTokenHandler.GetPrincipalAsync(request.Form.ToDictionary(pair => pair.Key, pair => pair.Value), out var stateStringFromRequest);
+            var principalContainer = await authTokenHandler.GetPrincipalAsync(request.Form.ToDictionary(pair => pair.Key, pair => (string?)pair.Value), out var stateStringFromRequest);
             var principal = principalContainer.Principal;
             if (principal == null || !string.IsNullOrEmpty(principalContainer.Error))
             {
@@ -239,10 +239,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
 
         Identity NewIdentity(UserResource userResource)
         {
-            return identityCreator.Create(
-                userResource.EmailAddress,
-                userResource.DisplayName,
-                userResource.ExternalId);
+            return identityCreator.Create(userResource);
         }
     }
 }


### PR DESCRIPTION
This back-ports a fix, to allow Okta to use the preferred_username as a the username identifier when matching Okta users in Octopus.  (https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders/pull/48)