### PR TITLE
Update google auth button to closer align with google guidelines

### DIFF
--- a/source/Server.GoogleApps/Web/Static/areas/users/googleApps_auth_provider.js
+++ b/source/Server.GoogleApps/Web/Static/areas/users/googleApps_auth_provider.js
@@ -6,8 +6,8 @@ function googleAuthProvider(octopusClient, provider, loginState, onError, isDark
             <div class="googleapps-button ${isDarkMode ? "dark" : "light"}>
                 <div class="googleapps-button-image">
                     <img alt="Login using Google Auth" src="${octopusClient.resolve("~/images/google_signin_buttons/icon-google.svg")}" />
-                    <span class="googleapps-button-text">Sign in with Google</span>
                 </div>
+                <span class="googleapps-button-text">Sign in with Google</span>
             </div>
         </a>
     `;

--- a/source/Server.GoogleApps/Web/Static/areas/users/googleApps_auth_provider.js
+++ b/source/Server.GoogleApps/Web/Static/areas/users/googleApps_auth_provider.js
@@ -1,8 +1,16 @@
 (function (providerName) {
 
-function googleAuthProvider(octopusClient, provider, loginState, onError) {
-
-    this.linkHtml = '<a><div class="googleapps-button"><img src="' + octopusClient.resolve("~/images/google_signin_buttons/icon-google.svg") + '" /><div>Sign in with Google</div></div></a>';
+function googleAuthProvider(octopusClient, provider, loginState, onError, isDarkMode) {
+    this.linkHtml = `
+        <a>
+            <div class="googleapps-button ${isDarkMode ? "dark" : "light"}>
+                <div class="googleapps-button-image">
+                    <img alt="Login using Google Auth" src="${octopusClient.resolve("~/images/google_signin_buttons/icon-google.svg")}" />
+                    <span class="googleapps-button-text">Sign in with Google</span>
+                </div>
+            </div>
+        </a>
+    `;
 
     this.signIn = function () {
 

--- a/source/Server.GoogleApps/Web/Static/areas/users/googleApps_auth_provider.js
+++ b/source/Server.GoogleApps/Web/Static/areas/users/googleApps_auth_provider.js
@@ -3,7 +3,7 @@
 function googleAuthProvider(octopusClient, provider, loginState, onError, isDarkMode) {
     this.linkHtml = `
         <a>
-            <div class="googleapps-button ${isDarkMode ? "dark" : "light"}>
+            <div class="googleapps-button ${isDarkMode ? "dark" : "light"}">
                 <div class="googleapps-button-image">
                     <img alt="Login using Google Auth" src="${octopusClient.resolve("~/images/google_signin_buttons/icon-google.svg")}" />
                 </div>

--- a/source/Server.GoogleApps/Web/Static/areas/users/googleApps_auth_provider.js
+++ b/source/Server.GoogleApps/Web/Static/areas/users/googleApps_auth_provider.js
@@ -1,6 +1,7 @@
 (function (providerName) {
 
 function googleAuthProvider(octopusClient, provider, loginState, onError, isDarkMode) {
+    //The following styling and structure is following google's branding guidelines. Please see https://developers.google.com/identity/branding-guidelines
     this.linkHtml = `
         <a>
             <div class="googleapps-button ${isDarkMode ? "dark" : "light"}">

--- a/source/Server.GoogleApps/Web/Static/images/google_signin_buttons/icon-google.svg
+++ b/source/Server.GoogleApps/Web/Static/images/google_signin_buttons/icon-google.svg
@@ -1,17 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="22px" height="14px" viewBox="0 0 22 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: sketchtool 40.1 (33804) - http://www.bohemiancoding.com/sketch -->
-    <title>48F98C86-FAB5-441C-B4F8-4FAD7646A716</title>
-    <desc>Created with sketchtool.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="2.-Login-Page" transform="translate(-606.000000, -611.000000)" fill="#FFFFFF">
-            <g id="Sign-in-with-Google" transform="translate(598.000000, 598.000000)">
-                <g id="icon-google" transform="translate(8.000000, 13.000000)">
-                    <path d="M7,8.4 L10.97,8.4 C10.81,9.43 9.77,11.42 7,11.42 C4.61,11.42 2.66,9.44 2.66,7 C2.66,4.56 4.61,2.58 7,2.58 C8.36,2.58 9.27,3.16 9.79,3.66 L11.69,1.83 C10.47,0.69 8.89,0 7,0 C3.13,0 0,3.13 0,7 C0,10.87 3.13,14 7,14 C11.04,14 13.72,11.16 13.72,7.16 C13.72,6.7 13.67,6.35 13.61,6 L7,6 L7,8.4 Z" id="G"></path>
-                    <polyline id="+" points="22 6 20 6 20 4 18 4 18 6 16 6 16 8 18 8 18 10 20 10 20 8 22 8"></polyline>
-                </g>
-            </g>
-        </g>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="18px" height="18px" viewBox="0 0 48 48">
+    <g>
+        <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>
+        <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"></path>
+        <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"></path>
+        <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"></path>
+        <path fill="none" d="M0 0h48v48H0z"></path>
     </g>
 </svg>

--- a/source/Server.GoogleApps/Web/Static/styles/googleApps.css
+++ b/source/Server.GoogleApps/Web/Static/styles/googleApps.css
@@ -35,9 +35,6 @@
 
 .googleapps-button-text {
     padding: 0.8125rem;
-}
-
-.googleapps-button div {
     font-family: "Roboto", sans-serif;
     font-weight: 600;
     text-align: left;

--- a/source/Server.GoogleApps/Web/Static/styles/googleApps.css
+++ b/source/Server.GoogleApps/Web/Static/styles/googleApps.css
@@ -1,28 +1,43 @@
 ﻿.googleapps-button {
-    background-color: #dc4e41;
-    color: #ffffff;
     cursor: pointer;
     border-radius: 2px;
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.24), 0 0 1px 0 rgba(0, 0, 0, 0.12);
     display: flex;
-    align-items: center;
-    padding-top: 0.8125rem;
-    padding-bottom: 0.8125rem;
+    align-items: stretch;
 }
 
-.googleapps-button:hover {
-    background-color: #c53829;
+.googleapps-button-image {
+    padding: 0.8125rem;
 }
 
-.googleapps-button img {
-    margin-left: 0.8125rem;
+.googleapps-button.light {
+    background-color: #fff;
+    color: #757575;
+}
+
+.googleapps-button.dark {
+    background-color: #4285f4;
+    color: #fff;
+}
+
+.googleapps-button:hover{
+    box-shadow: 0 0 3px 3px rgba(66,133,244,.3);
+}
+
+.googleapps-button.dark > .googleapps-button-image {
+    background-color: #fff;
+
+    border: solid 1px #4285f4;
+}
+
+.googleapps-button-text {
+    padding: 0.8125rem;
 }
 
 .googleapps-button div {
-    font-family: 'Roboto', sans-serif;
+    font-family: "Roboto", sans-serif;
     font-weight: 600;
     display: inline-block;
     text-align: left;
-    margin-left: 0.8125rem;
     overflow: hidden;
 }

--- a/source/Server.GoogleApps/Web/Static/styles/googleApps.css
+++ b/source/Server.GoogleApps/Web/Static/styles/googleApps.css
@@ -7,7 +7,11 @@
 }
 
 .googleapps-button-image {
-    padding: 0.8125rem;
+    display:flex;
+    justify-content: center;
+    align-items: center;
+    padding-left: 0.8125rem;
+    padding-right: 0.8125rem;
 }
 
 .googleapps-button.light {
@@ -26,7 +30,6 @@
 
 .googleapps-button.dark > .googleapps-button-image {
     background-color: #fff;
-
     border: solid 1px #4285f4;
 }
 
@@ -37,7 +40,6 @@
 .googleapps-button div {
     font-family: "Roboto", sans-serif;
     font-weight: 600;
-    display: inline-block;
     text-align: left;
     overflow: hidden;
 }


### PR DESCRIPTION
This PR updates the google auth button to closer align with google's [guidelines](https://developers.google.com/identity/branding-guidelines). We were previously using the G+ logo which has been dead for quite some time.

Related Server [PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/10371)

# Before

![image](https://user-images.githubusercontent.com/6700195/135950646-6bf14965-058f-4beb-a172-166445739407.png)
![image](https://user-images.githubusercontent.com/6700195/135950650-98537151-4f2c-474e-ace7-6fa58e43006f.png)

# After
![image](https://user-images.githubusercontent.com/6700195/135950668-4cc7f47e-95e5-4d3e-bda7-873d473dd51e.png)
![image](https://user-images.githubusercontent.com/6700195/135950677-85781388-780e-447a-8362-32aea7225be6.png)
