### PR TITLE
Make OctoupsID configuration writable so our Cloud Platform can use it configure hosted Octopus Server instances

### DIFF
--- a/source/Server.OctopusID/Configuration/OctopusIDConfigurationResource.cs
+++ b/source/Server.OctopusID/Configuration/OctopusIDConfigurationResource.cs
@@ -11,7 +11,20 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
         [ReadOnly(true)]
         public override string? Issuer { get; set; }
 
+        /// <summary>
+        /// NOTE: the following properties are here to control the order they appear on the settings page
+        /// </summary>
+
+        [Writeable]
+        public override string? ClientId { get; set; }
+
+        [Writeable]
+        public override SensitiveValue? ClientSecret { get; set; }
+
         [ReadOnly(true)]
         public override bool? AllowAutoUserCreation { get; set; }
+
+        [ReadOnly(true)]
+        public new bool IsEnabled { get; set; }
     }
 }

--- a/source/Server.OctopusID/Configuration/OctopusIDConfigurationResource.cs
+++ b/source/Server.OctopusID/Configuration/OctopusIDConfigurationResource.cs
@@ -8,7 +8,7 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
     [Description("Sign in to your Octopus Server with an Octopus ID. [Learn more](https://g.octopushq.com/AuthOctopusID).")]
     class OctopusIDConfigurationResource : OpenIDConnectConfigurationWithClientSecretResource
     {
-        [ReadOnly(true)]
+        [Writeable]
         public override string? Issuer { get; set; }
 
         /// <summary>
@@ -21,10 +21,7 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
         [Writeable]
         public override SensitiveValue? ClientSecret { get; set; }
 
-        [ReadOnly(true)]
+        [Writeable]
         public override bool? AllowAutoUserCreation { get; set; }
-
-        [ReadOnly(true)]
-        public new bool IsEnabled { get; set; }
     }
 }

--- a/source/Server.OctopusID/Configuration/OctopusIDConfigurationResource.cs
+++ b/source/Server.OctopusID/Configuration/OctopusIDConfigurationResource.cs
@@ -11,17 +11,7 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
         [ReadOnly(true)]
         public override string? Issuer { get; set; }
 
-        /// <summary>
-        /// NOTE: the following properties are here to control the order they appear on the settings page
-        /// </summary>
-
-        [Writeable]
-        public override string? ClientId { get; set; }
-
-        [Writeable]
-        public override SensitiveValue? ClientSecret { get; set; }
-
-        [Writeable]
+        [ReadOnly(true)]
         public override bool? AllowAutoUserCreation { get; set; }
     }
 }

--- a/source/Server.OctopusID/Configuration/OctopusIDConfigurationResource.cs
+++ b/source/Server.OctopusID/Configuration/OctopusIDConfigurationResource.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Configuration;
 using Octopus.Server.MessageContracts;
+using Octopus.Server.MessageContracts.Attributes;
 
 namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
 {
@@ -14,12 +15,13 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
         /// NOTE: the following properties are here to control the order they appear on the settings page
         /// </summary>
 
+        [Writeable]
         public override string? ClientId { get; set; }
 
+        [Writeable]
         public override SensitiveValue? ClientSecret { get; set; }
 
+        [Writeable]
         public override bool? AllowAutoUserCreation { get; set; }
-
-        public new bool IsEnabled { get; set; }
     }
 }

--- a/source/Server.OctopusID/Configuration/OctopusIDConfigurationResource.cs
+++ b/source/Server.OctopusID/Configuration/OctopusIDConfigurationResource.cs
@@ -14,14 +14,12 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID.Configuration
         /// NOTE: the following properties are here to control the order they appear on the settings page
         /// </summary>
 
-        [ReadOnly(true)]
         public override string? ClientId { get; set; }
-        [ReadOnly(true)]
+
         public override SensitiveValue? ClientSecret { get; set; }
-        [ReadOnly(true)]
+
         public override bool? AllowAutoUserCreation { get; set; }
 
-        [ReadOnly(true)]
         public new bool IsEnabled { get; set; }
     }
 }


### PR DESCRIPTION
Our Cloud Platform currently uses the CLI to configure Octopus ID on a hosted instance. It would be quicker and more reliable to do this via the REST API.

We need to make these properties writable to facilitate this. Octopus Server will then enforce the appropriate permissions

https://trello.com/c/EHAyPCu1/690-improve-the-performance-of-configureinstanceaccess-step-in-customizehostedinstancebackgroundprocess

https://octopusdeploy.slack.com/archives/C01HZFJRYSH/p1643684744224069?thread_ts=1643590290.269429&cid=C01HZFJRYSH