### PR TITLE
Add an explicit check for OctopusID when deciding auth code flow vs hybrid flow

### DIFF
--- a/source/Server.OpenIDConnect.Common/Issuer/AuthorizationEndpointUrlBuilder.cs
+++ b/source/Server.OpenIDConnect.Common/Issuer/AuthorizationEndpointUrlBuilder.cs
@@ -16,7 +16,10 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Issue
             this.urlEncoder = urlEncoder;
         }
 
-        protected virtual string ResponseType => ConfigurationStore.HasClientSecret ? OpenIDConnectConfiguration.AuthCodeResponseType : OpenIDConnectConfiguration.HybridResponseType;
+        // TODO: Remove the explicit check for OctopusID once OctopusID supports auth code flow
+        protected virtual string ResponseType => ConfigurationStore.HasClientSecret && ConfigurationStore.ConfigurationSettingsName != "OctopusID"
+            ? OpenIDConnectConfiguration.AuthCodeResponseType
+            : OpenIDConnectConfiguration.HybridResponseType;
         protected virtual string ResponseMode => OpenIDConnectConfiguration.DefaultResponseMode;
 
         public virtual string Build(string requestDirectoryPath, IssuerConfiguration issuerConfiguration, string? nonce = null, string? state = null, string? codeChallenge = null)

--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticationAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticationAction.cs
@@ -79,7 +79,8 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
                 var issuer = ConfigurationStore.GetIssuer() ?? string.Empty;
                 var issuerConfig = await identityProviderConfigDiscoverer.GetConfigurationAsync(issuer);
 
-                var response = ConfigurationStore.HasClientSecret
+                // TODO: Remove the explicit check for OctopusID once OctopusID supports auth code flow
+                var response = ConfigurationStore.HasClientSecret && ConfigurationStore.ConfigurationSettingsName != "OctopusID"
                     ? await BuildAuthorizationCodePkceResponse(model, new LoginStateWithRequestId(state.RedirectAfterLoginTo, state.UsingSecureConnection, Guid.NewGuid()), issuerConfig)
                     : BuildHybridResponse(model, state, issuerConfig);
 


### PR DESCRIPTION
OctopusID doesn't support auth code flow yet https://github.com/OctopusDeploy/Issues/issues/7504. We'll go with the old flow until it is supported, then we should be able to remove these checks.

Feature branch instance with working OctopusID DNS prefix="nelson-s"