### PR TITLE
Calculate scheme instead of using request.Scheme

### DIFF
--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedPkceAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedPkceAction.cs
@@ -80,8 +80,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
 
         async Task<IOctoResponseProvider> Handle(string code, string state, IOctoRequest request)
         {
-            var host = request.Headers.ContainsKey("Host") ? request.Headers["Host"].Single() : request.Host;
-            var redirectUri = $"{request.Scheme}://{host}{configurationStore.RedirectUri}";
+            var redirectUri = $"{request.Scheme}://{request.Host}{configurationStore.RedirectUri}";
             var stateFromRequest = JsonConvert.DeserializeObject<LoginStateWithRequestId>(state)!;
 
             using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));

--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedPkceAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedPkceAction.cs
@@ -80,10 +80,10 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
 
         async Task<IOctoResponseProvider> Handle(string code, string state, IOctoRequest request)
         {
+            var stateFromRequest = JsonConvert.DeserializeObject<LoginStateWithRequestId>(state)!;
             var redirectUri = $"{request.Scheme}://{request.Host}{configurationStore.RedirectUri}";
             var headersHost = request.Headers["Host"].Single();
-            return UserAuthenticatedValidator.BadRequest(log, $"redirectUri: {redirectUri}, headers host: {headersHost}");
-            var stateFromRequest = JsonConvert.DeserializeObject<LoginStateWithRequestId>(state)!;
+            return UserAuthenticatedValidator.BadRequest(log, $"redirectUri: {redirectUri}, headers host: {headersHost}, usingSecuredConnection: {stateFromRequest.UsingSecureConnection}, isHttps: {request.IsHttps}");
 
             using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
             var codeVerifier = await GetCodeVerifier(stateFromRequest.RequestId, cts.Token);

--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedPkceAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedPkceAction.cs
@@ -81,6 +81,8 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
         async Task<IOctoResponseProvider> Handle(string code, string state, IOctoRequest request)
         {
             var redirectUri = $"{request.Scheme}://{request.Host}{configurationStore.RedirectUri}";
+            var headersHost = request.Headers["Host"].Single();
+            return UserAuthenticatedValidator.BadRequest(log, $"redirectUri: {redirectUri}, headers host: {headersHost}");
             var stateFromRequest = JsonConvert.DeserializeObject<LoginStateWithRequestId>(state)!;
 
             using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));


### PR DESCRIPTION
The redirect URI was being incorrectly constructed before on cloud. This should fix that.

Feature branch instance: `nelson-s`