### PR TITLE
Remove async name to conform to server convention

### DIFF
--- a/source/Server.OctopusID/OctopusIdConfigDiscoverer.cs
+++ b/source/Server.OctopusID/OctopusIdConfigDiscoverer.cs
@@ -5,7 +5,7 @@ namespace Octopus.Server.Extensibility.Authentication.OctopusID
 {
     class OctopusIdConfigDiscoverer : IOctopusIdentityProviderConfigDiscoverer
     {
-        public Task<IssuerConfiguration> GetConfigurationAsync(string issuer)
+        public Task<IssuerConfiguration> GetConfiguration(string issuer)
         {
             return Task.FromResult(new IssuerConfiguration
             {

--- a/source/Server.OpenIDConnect.Common/Issuer/IIdentityProviderConfigDiscoverer.cs
+++ b/source/Server.OpenIDConnect.Common/Issuer/IIdentityProviderConfigDiscoverer.cs
@@ -4,6 +4,6 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Issue
 {
     public interface IIdentityProviderConfigDiscoverer
     {
-        Task<IssuerConfiguration> GetConfigurationAsync(string issuer);
+        Task<IssuerConfiguration> GetConfiguration(string issuer);
     }
 }

--- a/source/Server.OpenIDConnect.Common/Issuer/IdentityProviderConfigDiscoverer.cs
+++ b/source/Server.OpenIDConnect.Common/Issuer/IdentityProviderConfigDiscoverer.cs
@@ -11,7 +11,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Issue
     {
         readonly Dictionary<string, IssuerConfiguration> configurations = new Dictionary<string, IssuerConfiguration>();
 
-        public async Task<IssuerConfiguration> GetConfigurationAsync(string issuer)
+        public async Task<IssuerConfiguration> GetConfiguration(string issuer)
         {
             if (configurations.ContainsKey(issuer))
                 return configurations[issuer];

--- a/source/Server.OpenIDConnect.Common/Tokens/AuthTokenHandler.cs
+++ b/source/Server.OpenIDConnect.Common/Tokens/AuthTokenHandler.cs
@@ -41,7 +41,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Token
             ClaimsPrincipal? principal = null;
 
             var issuer = ConfigurationStore.GetIssuer() ?? string.Empty;
-            var issuerConfig = await identityProviderConfigDiscoverer.GetConfigurationAsync(issuer);
+            var issuerConfig = await identityProviderConfigDiscoverer.GetConfiguration(issuer);
 
             var validationParameters = new TokenValidationParameters
             {

--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedPkceAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticatedPkceAction.cs
@@ -123,7 +123,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
 
         async Task<IDictionary<string, string?>> RequestAuthToken(string code, string redirectUri, string codeVerifier)
         {
-            var issuerConfig = await identityProviderConfigDiscoverer.GetConfigurationAsync(configurationStore.GetIssuer() ?? string.Empty);
+            var issuerConfig = await identityProviderConfigDiscoverer.GetConfiguration(configurationStore.GetIssuer() ?? string.Empty);
             using var client = new HttpClient();
             var request = new HttpRequestMessage(HttpMethod.Post, issuerConfig.TokenEndpoint);
 

--- a/source/Server.OpenIDConnect.Common/Web/UserAuthenticationAction.cs
+++ b/source/Server.OpenIDConnect.Common/Web/UserAuthenticationAction.cs
@@ -77,7 +77,7 @@ namespace Octopus.Server.Extensibility.Authentication.OpenIDConnect.Common.Web
             try
             {
                 var issuer = ConfigurationStore.GetIssuer() ?? string.Empty;
-                var issuerConfig = await identityProviderConfigDiscoverer.GetConfigurationAsync(issuer);
+                var issuerConfig = await identityProviderConfigDiscoverer.GetConfiguration(issuer);
 
                 // TODO: Remove the explicit check for OctopusID once OctopusID supports auth code flow
                 var response = ConfigurationStore.HasClientSecret && ConfigurationStore.ConfigurationSettingsName != "OctopusID"

--- a/source/Tests/OctopusID/OctopusIdConfigDiscovererFixture.cs
+++ b/source/Tests/OctopusID/OctopusIdConfigDiscovererFixture.cs
@@ -14,7 +14,7 @@ namespace Tests.OctopusID
         {
             var sut = new OctopusIdConfigDiscoverer();
 
-            var result = await sut.GetConfigurationAsync(inputIssuer);
+            var result = await sut.GetConfiguration(inputIssuer);
 
             Assert.AreEqual(expectedOutputIssuer, result.Issuer);
             Assert.AreEqual(expectedAuthorizationEndpoint, result.AuthorizationEndpoint);

--- a/source/Tests/OpenIdConnect/Tokens/OpenIDConnectAuthTokenHandlerFixture.cs
+++ b/source/Tests/OpenIdConnect/Tokens/OpenIDConnectAuthTokenHandlerFixture.cs
@@ -52,7 +52,7 @@ namespace Tests.OpenIdConnect.Tokens
             configurationStore.GetIssuer().Returns(DefaultIssuer);
             configurationStore.GetClientId().Returns(DefaultClientId);
 
-            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+            identityProviderConfigDiscoverer.GetConfiguration(DefaultIssuer)
                 .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
 
             keyRetriever.GetKeysAsync(issuerConfig, false)
@@ -94,7 +94,7 @@ namespace Tests.OpenIdConnect.Tokens
             configurationStore.GetIssuer().Returns(DefaultIssuer);
             configurationStore.GetClientId().Returns(DefaultClientId);
 
-            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+            identityProviderConfigDiscoverer.GetConfiguration(DefaultIssuer)
                 .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
 
             // On first call to keyRetriever return invalid (stale) key
@@ -142,7 +142,7 @@ namespace Tests.OpenIdConnect.Tokens
             configurationStore.GetIssuer().Returns(DefaultIssuer);
             configurationStore.GetClientId().Returns(DefaultClientId);
 
-            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+            identityProviderConfigDiscoverer.GetConfiguration(DefaultIssuer)
                 .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
 
             // set keyRetriever to always return invalid (stale) key
@@ -172,7 +172,7 @@ namespace Tests.OpenIdConnect.Tokens
             configurationStore.GetIssuer().Returns(DefaultIssuer);
             configurationStore.GetClientId().Returns(DefaultClientId);
 
-            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+            identityProviderConfigDiscoverer.GetConfiguration(DefaultIssuer)
                 .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
 
             keyRetriever.GetKeysAsync(issuerConfig, false)

--- a/source/Tests/OpenIdConnect/Tokens/OpenIDConnectWithRolesAuthTokenHandlerFixture.cs
+++ b/source/Tests/OpenIdConnect/Tokens/OpenIDConnectWithRolesAuthTokenHandlerFixture.cs
@@ -50,7 +50,7 @@ namespace Tests.OpenIdConnect.Tokens
             configurationStore.GetClientId().Returns(DefaultClientId);
             configurationStore.GetRoleClaimType().Returns("roles");
 
-            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+            identityProviderConfigDiscoverer.GetConfiguration(DefaultIssuer)
                 .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
 
             keyRetriever.GetKeysAsync(issuerConfig, false)
@@ -81,7 +81,7 @@ namespace Tests.OpenIdConnect.Tokens
             configurationStore.GetClientId().Returns(DefaultClientId);
             configurationStore.GetRoleClaimType().Returns("groups");
 
-            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+            identityProviderConfigDiscoverer.GetConfiguration(DefaultIssuer)
                 .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
 
             keyRetriever.GetKeysAsync(issuerConfig, false)
@@ -112,7 +112,7 @@ namespace Tests.OpenIdConnect.Tokens
             configurationStore.GetClientId().Returns(DefaultClientId);
             configurationStore.GetRoleClaimType().Returns("roles");
 
-            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+            identityProviderConfigDiscoverer.GetConfiguration(DefaultIssuer)
                 .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
 
             keyRetriever.GetKeysAsync(issuerConfig, false)
@@ -145,7 +145,7 @@ namespace Tests.OpenIdConnect.Tokens
             configurationStore.GetClientId().Returns(DefaultClientId);
             configurationStore.GetRoleClaimType().Returns("groups");
 
-            identityProviderConfigDiscoverer.GetConfigurationAsync(DefaultIssuer)
+            identityProviderConfigDiscoverer.GetConfiguration(DefaultIssuer)
                 .Returns(Task.FromResult<IssuerConfiguration>(issuerConfig));
 
             keyRetriever.GetKeysAsync(issuerConfig, false)


### PR DESCRIPTION
When we moved this provider into octopus server, we updated one of the methods on the common interface to conform to the naming convention. 

Updating it here, so that anyone loading a custom extension can bring their own dll, and not have octopus ID complain in server.